### PR TITLE
fix: guard totalCostEur against null (Settings crash)

### DIFF
--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -447,7 +447,7 @@ onMounted(() => {
           <p class="text-sm text-gray-600">
             <strong>{{ totalLogs }}</strong> Ladevorgänge ·
             <strong>{{ Math.round(totalKwh) }}</strong> kWh ·
-            <strong>€{{ totalCostEur.toFixed(2) }}</strong>
+            <strong>€{{ (totalCostEur ?? 0).toFixed(2) }}</strong>
           </p>
         </div>
 


### PR DESCRIPTION
## Problem

Auf der Settings-Seite (`/settings`) wurde `totalCostEur.toFixed(2)` aufgerufen, obwohl die API `null` zurückgeben kann (z.B. bei neuen Usern ohne Ladevorgänge). Das führte zu einem `TypeError: Cannot call .toFixed() on null/undefined`.

Dieser Bug wurde von **4 separaten Usern** gemeldet (Issues #6, #8, #9, #12 - alle am selben Tag).

## Root Cause

```ts
const totalCostEur = ref(0)
// ...
totalCostEur.value = stats.totalCostEur  // kann null sein!
```

Im Template:
```html
<strong>€{{ totalCostEur.toFixed(2) }}</strong>  <!-- crash wenn null -->
```

## Fix

Nullish-Fallback vor `.toFixed()`:
```html
<strong>€{{ (totalCostEur ?? 0).toFixed(2) }}</strong>
```

## Test plan

- [ ] Settings-Seite aufrufen als neuer User ohne Logs - sollte €0.00 zeigen
- [ ] Settings-Seite aufrufen als User mit Logs - zeigt korrekte Kosten

Closes #6, #8, #9, #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)