### PR TITLE
fix: filter Safari autofill false positives from error reporting

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -56,6 +56,8 @@ if (import.meta.env.PROD) {
         // Ignore browser extension errors (e.g. chrome.runtime.sendMessage from ad blockers, password managers)
         const message = event.reason instanceof Error ? event.reason.message : String(event.reason)
         if (message.includes('runtime.sendMessage') || message.includes('extension')) return
+        // Ignore known WebKit/Safari internal autofill errors — not our code
+        if (message.includes('autofillFieldData')) return
         reportError(event.reason, 'unhandledrejection')
     })
 }


### PR DESCRIPTION
## Problem

Safari/WebKit wirft intern einen `unhandledrejection`-Fehler wenn eine Seite mit Formularfeldern aufgerufen wird. Die Fehlermeldung enthält `autofillFieldData.autoCompleteType.includes` und kommt aus dem Autofill-System des Browsers selbst - nicht aus unserem Code.

Da unser Error-Handler jeden `unhandledrejection` meldet, landeten diese Safari-Interlfehler als GitHub Issues (#4), obwohl es sich um einen bekannten WebKit-Bug handelt.

## Root Cause

Safari's internes Autofill-System hat einen Null-Check vergessen. Das ist *deren* Bug, nicht unserer. Wir kriegen es aber gemeldet weil unser globaler `unhandledrejection`-Handler greift.

```
TypeError: null is not an object (evaluating 'autofillFieldData.autoCompleteType.includes')
```

## Fix

Filter in `main.ts` analog zu den bereits vorhandenen Filtern für ServiceWorker- und Extension-Fehler:

```ts
if (message.includes('autofillFieldData')) return
```

## Test plan

- [ ] Settings-Seite mit Safari aufrufen - kein GitHub Issue wird erstellt
- [ ] Echter App-Fehler auf Settings - wird weiterhin gemeldet

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)