### PR TITLE
fix: return 400 Bad Request for malformed JSON (instead of 500)

### DIFF
--- a/backend/src/main/java/com/evmonitor/infrastructure/web/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/evmonitor/infrastructure/web/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -59,6 +60,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<Map<String, String>> handleAccessDenied(AccessDeniedException ex) {
         return ResponseEntity.status(403).body(Map.of("code", "FORBIDDEN", "message", "Zugriff verweigert."));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<Map<String, String>> handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of(
+                "code", "INVALID_JSON",
+                "message", "Ungültiges JSON-Format. Bitte überprüfe deine Anfrage."
+        ));
     }
 
     // Spring MVC 4xx – kein Alert, kein Log-Spam


### PR DESCRIPTION
## Problem

Wenn ein Client ungültiges JSON an `POST /api/v1/sessions` schickt (z.B. trailing comma), wirft Spring eine `HttpMessageNotReadableException`. Diese fiel bisher durch zum globalen Catch-All-Handler, der einen 500-Fehler zurückgibt und gleichzeitig ein GitHub Issue anlegt.

Das ist aber ein Client-Fehler (4xx) - kein Server-Fehler.

**Konkret aus Issue #11:**
```
JSON parse error: Unexpected character (',' (code 44)): expected a value
```

## Root Cause

`GlobalExceptionHandler` hatte keinen spezifischen Handler für `HttpMessageNotReadableException`, deshalb landete es beim generischen `Exception.class`-Handler.

## Fix

Spezifischer Handler in `GlobalExceptionHandler` der 400 zurückgibt - ohne GitHub Issue:

```java
@ExceptionHandler(HttpMessageNotReadableException.class)
public ResponseEntity<Map<String, String>> handleHttpMessageNotReadable(...) {
    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of(
        "code", "INVALID_JSON",
        "message", "Ungültiges JSON-Format. Bitte überprüfe deine Anfrage."
    ));
}
```

## Test plan

- [ ] `POST /api/v1/sessions` mit `{"sessions": [,]}` - bekommt 400, kein GitHub Issue
- [ ] `POST /api/v1/sessions` mit gültigem JSON - funktioniert weiterhin normal

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)