### PR TITLE
fix: guard LicensePlate against null plate prop (Dashboard crash)

### DIFF
--- a/frontend/src/components/LicensePlate.vue
+++ b/frontend/src/components/LicensePlate.vue
@@ -4,7 +4,7 @@ import { computed } from 'vue'
 const props = defineProps<{ plate: string }>()
 
 // FE-Engschrift ab 9 Zeichen (z.B. "M-EV 1234E")
-const isLong = computed(() => props.plate.replace(/\s/g, '').length >= 9)
+const isLong = computed(() => (props.plate ?? '').replace(/\s/g, '').length >= 9)
 </script>
 
 <template>
@@ -15,7 +15,7 @@ const isLong = computed(() => props.plate.replace(/\s/g, '').length >= 9)
       </div>
       <span class="eu-country">D</span>
     </div>
-    <span class="plate-text" :class="{ 'plate-text--eng': isLong }">{{ plate.toUpperCase() }}</span>
+    <span class="plate-text" :class="{ 'plate-text--eng': isLong }">{{ (plate ?? '').toUpperCase() }}</span>
   </div>
 </template>
 


### PR DESCRIPTION
## Problem

Der `LicensePlate`-Component ist auf dem Dashboard eingebunden (`v-if="car.licensePlate"`), aber durch Vue's reaktives Update-Cycle kann es eine kurze Phase geben, in der `props.plate` null/undefined ist, bevor das `v-if` greift. Das führte zum Crash:

```
TypeError: Cannot read properties of undefined (reading 'replace')
```

Der Fehler passiert in der computed property `isLong` und im Template:
```ts
const isLong = computed(() => props.plate.replace(/\s/g, '').length >= 9)
//                             ^^^^^^^^^^^^ crash wenn null
```

Obwohl alle Aufrufer `v-if="car.licensePlate"` nutzen, ist der Component bei Props, die sich reaktiv ändern, nicht vor Null-Werten geschützt.

## Fix

Nullish-Fallback auf `''` in computed und Template:

```ts
const isLong = computed(() => (props.plate ?? '').replace(/\s/g, '').length >= 9)
```

```html
<span>{{ (plate ?? '').toUpperCase() }}</span>
```

## Test plan

- [ ] Dashboard mit einem Auto ohne Kennzeichen - kein Crash
- [ ] Dashboard mit einem Auto mit Kennzeichen - Kennzeichen wird korrekt angezeigt

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)