### PR TITLE
fix: guard SpritMonitor new-car form against crash on /imports

### DIFF
--- a/frontend/src/components/SpritMonitorImport.vue
+++ b/frontend/src/components/SpritMonitorImport.vue
@@ -302,8 +302,9 @@ const close = () => {
                   </option>
                 </select>
 
-                <!-- Model Selection -->
+                <!-- Model Selection (only rendered once a brand was selected and newCarData is initialized) -->
                 <select
+                  v-if="newCarData[vehicle.id]"
                   v-model="newCarData[vehicle.id].model"
                   :disabled="!newCarData[vehicle.id]?.brand"
                   class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-lg focus:ring-2 focus:ring-indigo-500 disabled:bg-gray-100 dark:disabled:bg-gray-600">
@@ -312,9 +313,13 @@ const close = () => {
                     {{ model.label }}
                   </option>
                 </select>
+                <select v-else disabled class="w-full px-3 py-2 border border-gray-300 rounded-lg bg-gray-100 text-gray-400">
+                  <option>Erst Marke wählen</option>
+                </select>
 
                 <!-- Year Input -->
                 <input
+                  v-if="newCarData[vehicle.id]"
                   v-model.number="newCarData[vehicle.id].year"
                   type="number"
                   placeholder="Baujahr (z.B. 2023)"


### PR DESCRIPTION
## Problem

Auf der `/imports`-Seite im Sprit-Monitor Import: Wenn ein User bei der Fahrzeugzuordnung 'Neues Auto anlegen' auswählt, wird das Formular sofort gerendert. Das Template enthielt:

```html
v-model="newCarData[vehicle.id].model"
```

`newCarData[vehicle.id]` wird aber erst in `onBrandChange()` initialisiert (wenn der User eine Marke auswählt). Beim ersten Rendern ist das Objekt also `undefined`, und der Zugriff auf `.model` darauf wirft:

```
undefined is not an object (evaluating 'g.value[z.id].model')
```

## Root Cause

```ts
const newCarData = ref<Record<number, { brand: string; model: string; ... }>>({})
//                                                                              ^^ leer!
```

Das Template evaluated `v-model="newCarData[vehicle.id].model"` sofort wenn das Formular erscheint - bevor der User eine Marke gewählt hat und `onBrandChange()` aufgerufen wurde.

## Fix

Modell-Select und Baujahr-Input mit `v-if="newCarData[vehicle.id]"` guarden, sodass sie erst nach der ersten Marken-Auswahl rendern. Bis dahin wird ein disabled Placeholder angezeigt (gleiche UX wie vorher, nur ohne Crash).

## Test plan

- [ ] Sprit-Monitor Import starten (beliebiger Token), 'Neues Auto anlegen' auswählen - kein Crash
- [ ] Marke auswählen - Modell-Dropdown erscheint, Modelle werden geladen
- [ ] Modell + Baujahr auswählen - funktioniert normal

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)