### PR TITLE
fix: use REQUIRES_NEW for session grouping to prevent UnexpectedRollbackException

### DIFF
--- a/backend/src/main/java/com/evmonitor/application/SessionGroupService.java
+++ b/backend/src/main/java/com/evmonitor/application/SessionGroupService.java
@@ -8,6 +8,7 @@ import com.evmonitor.domain.EvLogRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
@@ -54,12 +55,14 @@ public class SessionGroupService {
      * Verarbeitet einen neu gespeicherten Log und gruppiert ihn zeitbasiert mit bestehenden Sessions.
      * Für WALLBOX_GOE und API_UPLOAD; andere Quellen werden ignoriert.
      *
-     * Läuft in derselben Transaktion wie der Log-Save (REQUIRED):
-     * Log-Save und Group-Linking sind atomic — entweder beide committed oder keiner.
+     * Läuft in einer eigenen Transaktion (REQUIRES_NEW) damit ein Fehler beim Grouping
+     * nicht die äußere Log-Save-Transaktion als rollback-only markiert. Die Caller
+     * (createWallboxLog, logCharging, PublicApiImportService) wollen den Log auch dann
+     * speichern wenn das Grouping fehlschlägt.
      *
      * @param savedLog Der gerade gespeicherte Log-Eintrag
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processSessionForGrouping(EvLog savedLog) {
         processSessionForGrouping(savedLog, DEFAULT_MERGE_GAP_MINUTES);
     }
@@ -71,7 +74,7 @@ public class SessionGroupService {
      * @param savedLog Der gerade gespeicherte Log-Eintrag
      * @param mergeGapMinutes Maximale Pause zwischen Sessions (in Minuten) für Gruppierung
      */
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void processSessionForGrouping(EvLog savedLog, int mergeGapMinutes) {
         // Nur WALLBOX_GOE und API_UPLOAD Sessions gruppieren
         if (savedLog.getDataSource() != DataSource.WALLBOX_GOE


### PR DESCRIPTION
## Problem

`POST /api/internal/logs` (Wallbox-Service) schlägt mit `UnexpectedRollbackException` fehl:

```
Transaction silently rolled back because it has been marked as rollback-only
  at EvLogService.createWallboxLog
  at InternalEvLogController.createWallboxLog
```

Dieses Problem tritt auf wenn `processSessionForGrouping()` intern eine Exception wirft (z.B. bei einem Duplicate-Key-Constraint beim Session-Grouping).

## Root Cause

**Das Spring Transaction Propagation Problem:**

```java
// createWallboxLog() - @Transactional (REQUIRED)
try {
    sessionGroupService.processSessionForGrouping(saved);  // auch @Transactional(REQUIRED)
} catch (Exception e) {
    logger.error("Session grouping failed...");  // Exception gefangen - alles gut?
}
// NEIN! processSessionForGrouping hat die Transaktion bereits als rollback-only markiert.
// Bei commit → UnexpectedRollbackException
```

Wenn `processSessionForGrouping` mit `REQUIRED` Propagation in der **selben Transaktion** läuft und eine unchecked Exception wirft, markiert Spring die gesamte Transaktion als rollback-only — **bevor** der try-catch sie fangen kann. Der catch-Block fängt die Exception, aber der Schaden ist schon angerichtet.

## Fix

`processSessionForGrouping` mit `Propagation.REQUIRES_NEW` ausführen lassen, sodass es eine **eigene, unabhängige Transaktion** bekommt:

- Grouping erfolgreich → eigene Transaktion committed, outer Transaktion unbeeinflusst
- Grouping schlägt fehl → nur die Grouping-Transaktion rollt zurück, **der Log-Save bleibt erhalten**

Das entspricht dem dokumentierten Intent (`"Fehler beim Grouping sollen den Log-Save NICHT rückgängig machen"`).

## Test plan

- [ ] Wallbox sendet Session → Log wird gespeichert
- [ ] Wallbox sendet Session die Grouping-Fehler auslöst → Log wird trotzdem gespeichert, kein 500
- [ ] Session-Grouping funktioniert weiterhin für normale Sessions

Closes #20, #31, #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)