### PR TITLE
fix: multiple frontend null guards (Zotero, CarManagement, Dashboard, Imports)

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -58,6 +58,8 @@ if (import.meta.env.PROD) {
         if (message.includes('runtime.sendMessage') || message.includes('extension')) return
         // Ignore known WebKit/Safari internal autofill errors — not our code
         if (message.includes('autofillFieldData')) return
+        // Ignore known browser extension errors (Zotero, etc.)
+        if (message.includes('Zotero') || message.includes('Failed to send message')) return
         reportError(event.reason, 'unhandledrejection')
     })
 }

--- a/frontend/src/views/CarManagementView.vue
+++ b/frontend/src/views/CarManagementView.vue
@@ -290,7 +290,8 @@ const setActiveCar = async (id: string) => {
   }
 }
 
-const getModelLabel = (modelValue: string): string => {
+const getModelLabel = (modelValue: string | null | undefined): string => {
+  if (!modelValue) return ''
   const model = availableModels.value.find(m => m.value === modelValue)
   if (model) return model.label
   return modelValue.replace(/_/g, ' ').toLowerCase()

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -577,12 +577,14 @@ const hasAnyLogs = computed(() => logs.value.length > 0 || sessionGroups.value.l
 
 // Merged + sorted feed: normale Logs und Gruppen nach Datum zusammenführen
 const mergedLogFeed = computed(() => {
-  const groupsForPage = sessionGroups.value.map((g: any) => ({
+  const safeGroups = Array.isArray(sessionGroups.value) ? sessionGroups.value : []
+  const safeLogs = Array.isArray(logs.value) ? logs.value : []
+  const groupsForPage = safeGroups.map((g: any) => ({
     ...g,
     _isGroup: g.dataSource !== 'SPRITMONITOR_IMPORT',
     _isSpritGroup: g.dataSource === 'SPRITMONITOR_IMPORT'
   }))
-  const logsWithFlag = logs.value.map((l: any) => ({ ...l, _isGroup: false, _isSpritGroup: false }))
+  const logsWithFlag = safeLogs.map((l: any) => ({ ...l, _isGroup: false, _isSpritGroup: false }))
   const sorted = [...logsWithFlag, ...groupsForPage].sort((a, b) => {
     const dateA = new Date((a._isGroup || a._isSpritGroup) ? a.sessionStart : a.loggedAt).getTime()
     const dateB = new Date((b._isGroup || b._isSpritGroup) ? b.sessionStart : b.loggedAt).getTime()

--- a/frontend/src/views/ImportsView.vue
+++ b/frontend/src/views/ImportsView.vue
@@ -102,11 +102,11 @@ async function toggleMergeSessions(key: ApiKeyResponse) {
 }
 
 const hasActiveTesla = computed(() =>
-  cars.value.some(c => c.brand?.toLowerCase() === 'tesla' && c.status === 'ACTIVE')
+  Array.isArray(cars.value) && cars.value.some(c => c.brand?.toLowerCase() === 'tesla' && c.status === 'ACTIVE')
 )
 
 const activeCars = computed(() =>
-  cars.value.filter(c => c.status === 'ACTIVE')
+  Array.isArray(cars.value) ? cars.value.filter(c => c.status === 'ACTIVE') : []
 )
 </script>
 


### PR DESCRIPTION
## Probleme

Mehrere unabhängige Frontend-Crashes:

### Issue #40 - Zotero Extension Noise (`main.ts`)
Der Zotero Connector (Browser-Extension für Literaturverwaltung) wirft einen `unhandledrejection`-Fehler der nicht von uns kommt. Wie bereits Safari Autofill und Chrome Extension Errors → gefiltert.

### Issue #27 - `getModelLabel` crash auf `/cars`
```ts
const getModelLabel = (modelValue: string): string => {
  return modelValue.replace(...)  // crash wenn car.model == null/undefined
}
```
Wenn ein Auto keinen Model-Wert hat, crasht die Fahrzeugverwaltungsseite.

### Issue #28 - `.some is not a function` auf `/imports`
```ts
const hasActiveTesla = computed(() => cars.value.some(...))
// crash wenn cars.value kein Array ist
```
`cars.value` kann in Edge-Cases (unerwartetes API-Format) temporär kein Array sein.

### Issue #38 - `.map is not a function` auf Dashboard
```ts
const mergedLogFeed = computed(() => {
  const groupsForPage = sessionGroups.value.map(...)  // crash
  const logsWithFlag = logs.value.map(...)             // crash
```
Gleiche Ursache - Array-Assumption ohne Guard.

## Fix

Defensive `Array.isArray()` und `!value` Guards in allen betroffenen Stellen.

## Test plan

- [ ] `/cars` mit Auto ohne Modell - kein Crash
- [ ] Dashboard lädt mit Logs und Gruppen - alles korrekt
- [ ] `/imports` lädt - kein Crash
- [ ] Zotero Extension aktiv + Seite aufrufen - kein GitHub Issue

Closes #40, #27, #28, #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)