### PR TITLE
fix: guard toFixed against null in SettingsView and ChargingHeatMap

### DIFF
--- a/frontend/src/components/ChargingHeatMap.vue
+++ b/frontend/src/components/ChargingHeatMap.vue
@@ -206,15 +206,17 @@ const renderCharges = async () => {
         hour: '2-digit',
         minute: '2-digit'
       })
-      const costPerKwh = log.kwhCharged > 0 ? (log.costEur / log.kwhCharged).toFixed(2) : '0.00'
+      const kwh = log.kwhCharged ?? 0
+      const cost = log.costEur ?? 0
+      const costPerKwh = kwh > 0 ? (cost / kwh).toFixed(2) : '0.00'
 
       marker.bindPopup(`
         <div style="font-family: system-ui; font-size: 13px; min-width: 180px;">
           <div style="font-weight: 700; font-size: 15px; margin-bottom: 6px; color: #1f2937;">
-            ⚡ ${log.kwhCharged.toFixed(1)} kWh
+            ⚡ ${kwh.toFixed(1)} kWh
           </div>
           <div style="display: flex; flex-direction: column; gap: 4px; color: #4b5563;">
-            <div>💰 €${log.costEur.toFixed(2)} <span style="color: #9ca3af;">(€${costPerKwh}/kWh)</span></div>
+            <div>💰 €${cost.toFixed(2)} <span style="color: #9ca3af;">(€${costPerKwh}/kWh)</span></div>
             <div>⏱️ ${log.chargeDurationMinutes} Minuten</div>
             <div>📅 ${date} · ${time}</div>
           </div>

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -79,7 +79,7 @@ const fetchUserData = async () => {
     registeredSince.value = new Date(stats.registeredSince).toLocaleDateString('de-DE')
     totalLogs.value = stats.totalLogs
     totalKwh.value = stats.totalKwh
-    totalCostEur.value = stats.totalCostEur
+    totalCostEur.value = stats.totalCostEur ?? 0
     referralCode.value = stats.referralCode || ''
     leaderboardVisible.value = stats.leaderboardVisible ?? true
 


### PR DESCRIPTION
## Probleme

### Issues #12, #21, #23, #25, #34, #36, #41 - \`totalCostEur.toFixed()\` Crash auf \`/settings\`

\`totalCostEur\` wird als \`ref(0)\` initialisiert, aber dann via API überschrieben:

```ts
totalCostEur.value = stats.totalCostEur  // kann null sein wenn User keine Kostendaten hat
```

Wenn die API \`null\` zurückgibt (z.B. kein einziger Log mit Kosten), wird \`null.toFixed(2)\` im Template zu einem Crash.

### ChargingHeatMap - \`kwhCharged.toFixed()\` und \`costEur.toFixed()\` Crash

Im Heatmap-Popup wurden \`log.kwhCharged\` und \`log.costEur\` direkt ohne Null-Guard verwendet:

```js
log.kwhCharged.toFixed(1)  // crash wenn null/undefined
log.costEur.toFixed(2)     // crash wenn null/undefined
```

## Fix

**SettingsView.vue:** Nullish coalescing beim Zuweisen aus der API-Antwort:
```ts
totalCostEur.value = stats.totalCostEur ?? 0
```

**ChargingHeatMap.vue:** Werte vor \`toFixed()\` mit \`?? 0\` absichern:
```js
const kwh = log.kwhCharged ?? 0
const cost = log.costEur ?? 0
```

## Test plan

- [ ] \`/settings\` aufrufen als User ohne Logs mit Kostendaten - kein Crash
- [ ] \`/settings\` aufrufen als normaler User - Kosten werden korrekt angezeigt
- [ ] Heatmap auf \`/dashboard\` mit Logs öffnen - Popups funktionieren
- [ ] Heatmap mit Logs ohne Kosten (costEur=null) - kein Crash

Closes #12, #21, #23, #25, #34, #36, #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)