### PR TITLE
fix: return 409 Conflict for duplicate log entries on POST /api/logs

### DIFF
--- a/backend/src/main/java/com/evmonitor/infrastructure/web/EvLogController.java
+++ b/backend/src/main/java/com/evmonitor/infrastructure/web/EvLogController.java
@@ -33,10 +33,15 @@ public class EvLogController {
     }
 
     @PostMapping
-    public ResponseEntity<EvLogCreateResponse> logCharging(@Valid @RequestBody EvLogRequest request, Authentication authentication) {
+    public ResponseEntity<?> logCharging(@Valid @RequestBody EvLogRequest request, Authentication authentication) {
         UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
-        EvLogCreateResponse response = evLogService.logCharging(principal.getUser().getId(), request);
-        return new ResponseEntity<>(response, HttpStatus.CREATED);
+        try {
+            EvLogCreateResponse response = evLogService.logCharging(principal.getUser().getId(), request);
+            return new ResponseEntity<>(response, HttpStatus.CREATED);
+        } catch (DataIntegrityViolationException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("message", "Ein Eintrag mit diesem Datum und dieser Uhrzeit existiert bereits für dieses Fahrzeug. Bitte ändere die Uhrzeit."));
+        }
     }
 
     @GetMapping


### PR DESCRIPTION
## Problem

Issues #10, #44: Der \`POST /api/logs\` Endpoint hat \`DataIntegrityViolationException\` (duplicate key) nicht abgefangen - stattdessen landete ein 500 Internal Server Error im Log.

```
DataIntegrityViolationException: duplicate key value violates unique constraint 
"uq_ev_log_car_loggedat_datasource"
Key (car_id, logged_at, data_source)=(..., USER_LOGGED) already exists.
```

Der \`PUT /api/logs/{id}\` Endpoint hat bereits einen korrekten Catch-Block der 409 zurückgibt - der war auf dem POST vergessen worden.

## Fix

Gleicher Catch-Block wie beim PUT Endpoint:

```java
} catch (DataIntegrityViolationException e) {
    return ResponseEntity.status(HttpStatus.CONFLICT)
            .body(Map.of("message", "Ein Eintrag mit diesem Datum und dieser Uhrzeit existiert bereits..."));
}
```

## Test plan

- [ ] Doppelten Log-Eintrag (gleicher Car, gleicher Timestamp) via POST anlegen - bekommt 409 mit verständlicher Fehlermeldung
- [ ] Normaler Log-Eintrag - weiterhin 201 Created

Closes #10, #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)