### PR TITLE
fix: prevent toFixed crash when avgConsumptionKwhPer100km is null

### DIFF
--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -933,8 +933,8 @@ const deleteLog = async (id: string) => {
                       <span class="font-normal">({{ stats.winterConsumptionKwhPer100km.toFixed(1) }}<span class="hidden sm:inline"> kWh/100km</span><span class="sm:hidden"> kWh</span>)</span>
                     </span>
                   </th>
-                  <th v-if="!stats?.summerConsumptionKwhPer100km && !stats?.winterConsumptionKwhPer100km" class="text-right pb-2 font-medium text-gray-600 dark:text-gray-300 whitespace-nowrap pl-4">
-                    <span class="font-normal">Ø ({{ stats.avgConsumptionKwhPer100km!.toFixed(1) }}<span class="hidden sm:inline"> kWh/100km</span><span class="sm:hidden"> kWh</span>)</span>
+                  <th v-if="!stats?.summerConsumptionKwhPer100km && !stats?.winterConsumptionKwhPer100km && stats?.avgConsumptionKwhPer100km != null" class="text-right pb-2 font-medium text-gray-600 dark:text-gray-300 whitespace-nowrap pl-4">
+                    <span class="font-normal">Ø ({{ stats.avgConsumptionKwhPer100km.toFixed(1) }}<span class="hidden sm:inline"> kWh/100km</span><span class="sm:hidden"> kWh</span>)</span>
                   </th>
                 </tr>
               </thead>


### PR DESCRIPTION
## Summary
- Fixes `TypeError: Cannot read properties of undefined (reading 'toFixed')` on `/dashboard`
- The `v-if` guard checked for summer/winter consumption but not for `avgConsumptionKwhPer100km` itself
- Users with charging logs but no odometer data have `null` for consumption metrics

## Root Cause
Line 937 in `DashboardView.vue` used the TypeScript non-null assertion operator `!` which is compile-time only. At runtime, `avgConsumptionKwhPer100km` can be `null` if no valid consumption can be calculated.

## Fix
Extended the `v-if` condition to also require `stats?.avgConsumptionKwhPer100km != null` before rendering the element.

## Closes
Fixes #84 #81 #73 #71 #67 #66 #63 #61 #59 #56