### PR TITLE
fix: allow custom model entry for unsupported brands (Andere Marke)

### DIFF
--- a/backend/src/main/java/com/evmonitor/domain/CarBrand.java
+++ b/backend/src/main/java/com/evmonitor/domain/CarBrand.java
@@ -303,7 +303,10 @@ public enum CarBrand {
       XPENG_G9(CarBrand.XPENG, VehicleCategory.LARGE_SUV, "G9", 78.2, 98.0),
       ZEEKR_001(CarBrand.ZEEKR, VehicleCategory.SEDAN, "001", 86.0, 100.0),
       ZEEKR_X(CarBrand.ZEEKR, VehicleCategory.COMPACT, "X", 64.0),
-      ORA_FUNKY_CAT(CarBrand.ORA, VehicleCategory.CITY_CAR, "Funky Cat", 48.0, 63.0);
+      ORA_FUNKY_CAT(CarBrand.ORA, VehicleCategory.CITY_CAR, "Funky Cat", 48.0, 63.0),
+
+      // --- SONSTIGE ---
+      SONSTIGE_CUSTOM(CarBrand.SONSTIGE, VehicleCategory.COMPACT, "Sonstiges Modell");
 
       private final CarBrand brand;
       private final VehicleCategory category;

--- a/frontend/src/locales/de.yaml
+++ b/frontend/src/locales/de.yaml
@@ -601,6 +601,7 @@ cars:
   toast_image_public: "Bild öffentlich geteilt! +{n} Watt erhalten!"
   toast_upload: "Foto hochgeladen! +{n} Watt erhalten!"
   trim_placeholder: "z.B. GTX, Pro Performance, Long Range"
+  trim_placeholder_sonstige: "z.B. C10 ProMax, BX3, Elroq 50"
   capacity_custom_placeholder: "z.B. 82,5"
   plate_placeholder: "z.B. M-EV 123"
   power_placeholder: "z.B. 150"

--- a/frontend/src/locales/en.yaml
+++ b/frontend/src/locales/en.yaml
@@ -601,6 +601,7 @@ cars:
   toast_image_public: "Image shared publicly! +{n} Watts earned!"
   toast_upload: "Photo uploaded! +{n} Watts earned!"
   trim_placeholder: "e.g. GTX, Pro Performance, Long Range"
+  trim_placeholder_sonstige: "e.g. C10 ProMax, BX3, Elroq 50"
   capacity_custom_placeholder: "e.g. 82.5"
   plate_placeholder: "e.g. AB-123 CD"
   power_placeholder: "e.g. 150"

--- a/frontend/src/views/CarManagementView.vue
+++ b/frontend/src/views/CarManagementView.vue
@@ -56,6 +56,8 @@ const sortedBrands = computed(() => {
   return [...brands.value].sort((a, b) => a.label.localeCompare(b.label))
 })
 
+const isSonstige = computed(() => selectedBrand.value === 'SONSTIGE')
+
 const selectedModelCapacities = computed(() => {
   if (!selectedModel.value) return []
   const model = availableModels.value.find(m => m.value === selectedModel.value)
@@ -148,16 +150,26 @@ watch(selectedBrand, (newBrand) => {
     availableModels.value = []
   }
   if (!editingCar.value) {
-    selectedModel.value = ''
     selectedCapacity.value = null
+    if (newBrand === 'SONSTIGE') {
+      selectedModel.value = 'SONSTIGE_CUSTOM'
+      useCustomCapacity.value = true
+    } else {
+      selectedModel.value = ''
+      useCustomCapacity.value = false
+    }
   }
 })
 
-watch(selectedModel, () => {
+watch(selectedModel, (newModel) => {
   if (!editingCar.value) {
     selectedCapacity.value = null
-    useCustomCapacity.value = false
-    customCapacity.value = null
+    if (newModel === 'SONSTIGE_CUSTOM') {
+      useCustomCapacity.value = true
+    } else {
+      useCustomCapacity.value = false
+      customCapacity.value = null
+    }
   }
   // Reset WLTP data when model changes
   wltpData.value = null
@@ -499,7 +511,7 @@ onUnmounted(() => {
               </select>
             </div>
 
-            <div>
+            <div v-if="!isSonstige">
               <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ t('cars.label_model') }}</label>
               <select v-model="selectedModel" required :disabled="!selectedBrand"
                 class="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 p-2 border disabled:bg-gray-100 dark:disabled:bg-gray-600 dark:bg-gray-700 dark:text-gray-100">
@@ -511,13 +523,13 @@ onUnmounted(() => {
             </div>
 
             <div>
-              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ t('cars.label_trim') }}</label>
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ isSonstige ? t('cars.label_model') : t('cars.label_trim') }}</label>
               <input
                 v-model="trim"
                 type="text"
-                :placeholder="t('cars.trim_placeholder')"
+                :placeholder="isSonstige ? t('cars.trim_placeholder_sonstige') : t('cars.trim_placeholder')"
                 class="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 p-2 border dark:bg-gray-700 dark:text-gray-100" />
-              <p class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ t('cars.hint_trim') }}</p>
+              <p v-if="!isSonstige" class="text-xs text-gray-500 dark:text-gray-400 mt-1">{{ t('cars.hint_trim') }}</p>
             </div>
 
             <!-- Capacity Selection -->
@@ -849,7 +861,7 @@ onUnmounted(() => {
               </select>
             </div>
 
-            <div>
+            <div v-if="!isSonstige">
               <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ t('cars.label_model') }}</label>
               <select v-model="selectedModel" required :disabled="!selectedBrand"
                 class="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 p-2 border disabled:bg-gray-100 dark:disabled:bg-gray-600 dark:bg-gray-700 dark:text-gray-100">
@@ -861,8 +873,9 @@ onUnmounted(() => {
             </div>
 
             <div>
-              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ t('cars.label_trim') }}</label>
-              <input v-model="trim" type="text" :placeholder="t('cars.trim_placeholder')"
+              <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{{ isSonstige ? t('cars.label_model') : t('cars.label_trim') }}</label>
+              <input v-model="trim" type="text"
+                :placeholder="isSonstige ? t('cars.trim_placeholder_sonstige') : t('cars.trim_placeholder')"
                 class="w-full rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 p-2 border dark:bg-gray-700 dark:text-gray-100" />
             </div>
 


### PR DESCRIPTION
## Summary
- Fixes #50 - users with cars not in the database (Leapmotor, BYD, etc.) can now add their vehicle
- Adds `SONSTIGE_CUSTOM` to the `CarModel` enum so the backend accepts a generic model entry for the SONSTIGE brand
- When "Andere Marke" is selected, the model dropdown is hidden and replaced with a free-text model name field (stored in `trim`)
- Custom battery capacity input is automatically activated since no predefined capacities exist

## User Impact
Before: form returned "model is invalid" validation error - **unusable**
After: user selects "Andere Marke", enters model name (e.g. "C10 ProMax") and battery capacity manually

## Closes
Fixes #50