### PR TITLE
fix: return 200 instead of 500 on duplicate API session upload

### DIFF
--- a/backend/src/main/java/com/evmonitor/infrastructure/web/PublicApiImportController.java
+++ b/backend/src/main/java/com/evmonitor/infrastructure/web/PublicApiImportController.java
@@ -6,6 +6,7 @@ import com.evmonitor.application.publicapi.PublicApiSessionRequest;
 import com.evmonitor.domain.ApiKey;
 import com.evmonitor.infrastructure.security.RateLimitService;
 import com.evmonitor.infrastructure.security.UserPrincipal;
+import org.springframework.dao.DataIntegrityViolationException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -89,6 +90,10 @@ public class PublicApiImportController {
         } catch (IllegalArgumentException e) {
             return ResponseEntity.badRequest()
                     .body(Map.of("error", e.getMessage()));
+        } catch (DataIntegrityViolationException e) {
+            // Race condition: duplicate session slipped past the isDuplicate check
+            // Return gracefully instead of 500
+            return ResponseEntity.ok(Map.of("imported", 0, "skipped", 1, "errors", 0));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fixes HTTP 500 errors when wallboxes/scripts send duplicate charging sessions via `POST /api/v1/sessions`
- The existing per-session duplicate check (`isDuplicate`) handles most cases, but a race condition exists when two concurrent requests arrive with the same session timestamp
- In that case, `DataIntegrityViolationException` is thrown during transaction commit - outside the inner `try/catch` - and propagated as an unhandled 500

## Root Cause
Spring JPA defers SQL execution until transaction commit. If two concurrent requests both pass the `isDuplicate` check (neither has committed yet), both queue an INSERT. The second commit fails with a unique constraint violation that was not caught at the controller level.

## Fix
Added a controller-level catch for `DataIntegrityViolationException` returning `{"imported": 0, "skipped": 1, "errors": 0}` with HTTP 200. This is consistent with the normal deduplication response format and prevents wallbox auto-sync tools from seeing errors.

## Closes
Fixes #54 #53