### PR TITLE
fix: disable caching for sw.js to prevent stale service worker errors

### DIFF
--- a/nginx/conf.d/app.conf.template
+++ b/nginx/conf.d/app.conf.template
@@ -111,6 +111,15 @@ server {
         return 404;
     }
 
+    # Service Worker - must never be cached so browsers always get the latest version
+    # Stale sw.js can reference workbox files from old deployments that no longer exist
+    location = /sw.js {
+        root /usr/share/nginx/html;
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        expires 0;
+    }
+
     location = /sitemap.xml {
         proxy_pass http://backend:8080/sitemap.xml;
         proxy_set_header Host $http_host;


### PR DESCRIPTION
## Summary
- Fixes repeated "Script https://ev-monitor.net/sw.js load failed" errors in browser
- Adds `Cache-Control: no-cache` to the nginx location for `sw.js`

## Root Cause
When a new frontend build is deployed, the workbox file hash changes (e.g. `workbox-8c29f6e4.js`). Browsers with a cached old `sw.js` try to load the old workbox hash which no longer exists on the server, causing the service worker registration to fail with "Script load failed".

## Fix
Added a dedicated nginx location for `sw.js` that disables caching. This ensures browsers always fetch the latest service worker file, preventing references to stale/removed workbox bundles.

## Closes
Fixes #74 #72 #68