### PR TITLE
fix: Premium sofort entziehen bei Stripe payment failure

### DIFF
--- a/backend/src/main/java/com/evmonitor/application/StripeService.java
+++ b/backend/src/main/java/com/evmonitor/application/StripeService.java
@@ -173,11 +173,15 @@ public class StripeService {
                 log.info("[STRIPE] subscription deleted -> isPremium=false for customer={}", customerId);
             }
             case "invoice.payment_failed" -> {
-                // Do NOT revoke premium immediately — Stripe retries the payment.
-                // Access is revoked naturally when the subscription transitions to
-                // past_due (via customer.subscription.updated) or is deleted.
+                // Revoke premium immediately — Stripe will retry the payment.
+                // If a retry succeeds, subscription.updated -> active restores premium.
+                // Smartcar stays connected so that recovery is seamless (no re-auth needed).
+                // Final cleanup (including Smartcar disconnect) happens on subscription.deleted.
                 String customerId = data.get("customer").getAsString();
-                log.warn("[STRIPE] payment failed for customer={} — Stripe will retry", customerId);
+                findUserByCustomerId(customerId).ifPresent(u -> {
+                    userRepository.setPremium(u.getId(), false);
+                });
+                log.warn("[STRIPE] payment failed for customer={} — premium revoked, Stripe will retry", customerId);
             }
             case "invoice.payment_succeeded" -> {
                 long amountPaid = data.get("amount_paid").getAsLong();

--- a/backend/src/test/java/com/evmonitor/application/StripeServiceTest.java
+++ b/backend/src/test/java/com/evmonitor/application/StripeServiceTest.java
@@ -308,16 +308,32 @@ class StripeServiceTest {
     class InvoicePaymentFailed {
 
         @Test
-        void onlyLogsWarning_noDbCallsMade() {
+        void setsPremiumFalse_immediately() {
+            User user = buildUser(USER_ID, null);
+            when(userRepository.findByStripeCustomerId(CUSTOMER_ID)).thenReturn(Optional.of(user));
+
             JsonObject data = JsonParser.parseString("""
                     {"customer": "%s"}
                     """.formatted(CUSTOMER_ID)).getAsJsonObject();
 
             stripeService.dispatch("invoice.payment_failed", data);
 
-            // payment_failed must never touch the DB — Stripe handles retries
+            // Premium is revoked immediately — but Smartcar stays connected for potential recovery.
+            // If Stripe retries and succeeds, subscription.updated -> active restores premium.
+            verify(userRepository).setPremium(USER_ID, false);
+        }
+
+        @Test
+        void unknownCustomerId_noDbCallsMade() {
+            when(userRepository.findByStripeCustomerId(CUSTOMER_ID)).thenReturn(Optional.empty());
+
+            JsonObject data = JsonParser.parseString("""
+                    {"customer": "%s"}
+                    """.formatted(CUSTOMER_ID)).getAsJsonObject();
+
+            stripeService.dispatch("invoice.payment_failed", data);
+
             verify(userRepository, never()).setPremium(any(), anyBoolean());
-            verify(userRepository, never()).findByStripeCustomerId(any());
         }
     }
 


### PR DESCRIPTION
Bisher wurde bei invoice.payment_failed nur geloggt und auf subscription.updated (past_due) gewartet. Jetzt wird Premium sofort entzogen, damit Smartcar-Webhooks keine Logs mehr für nicht-zahlende User erstellen. Smartcar-Connection bleibt erhalten, damit bei erfolgreicher Stripe-Retry nahtlos weitergeht.