### PR TITLE
feat(seo): 5 öffentliche Landing Pages für organischen Traffic

### DIFF
--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -395,6 +395,36 @@ const router = createRouter({
             component: () => import('../views/ConsumptionMethodologyView.vue')
         },
         {
+            path: '/ladekosten-rechner',
+            name: 'ladekosten-rechner',
+            component: () => import('../views/LadekostenRechnerView.vue')
+            // no auth guard - public SEO page
+        },
+        {
+            path: '/ladetagebuch',
+            name: 'ladetagebuch',
+            component: () => import('../views/LadetagebuchView.vue')
+            // no auth guard - public SEO page
+        },
+        {
+            path: '/echte-reichweite',
+            name: 'echte-reichweite',
+            component: () => import('../views/EchteReichweiteView.vue')
+            // no auth guard - public SEO page
+        },
+        {
+            path: '/verbrauch-verstehen',
+            name: 'verbrauch-verstehen',
+            component: () => import('../views/VerbrauchVerstehenView.vue')
+            // no auth guard - public SEO page
+        },
+        {
+            path: '/elektroauto-kosten-pro-km',
+            name: 'elektroauto-kosten-pro-km',
+            component: () => import('../views/ElektroautoKostenView.vue')
+            // no auth guard - public SEO page
+        },
+        {
             path: '/terms',
             name: 'terms',
             component: TermsView

--- a/frontend/src/utils/__tests__/ladekostenCalc.test.ts
+++ b/frontend/src/utils/__tests__/ladekostenCalc.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { kostenPro100km, kostenProKm, kostenProMonat, benzinKostenProMonat, ersparnisProMonat } from '../ladekostenCalc';
+
+describe('ladekostenCalc', () => {
+  it('kostenPro100km = strompreis × verbrauch', () => {
+    expect(kostenPro100km(0.33, 18)).toBeCloseTo(5.94);
+    expect(kostenPro100km(0.40, 20)).toBeCloseTo(8.00);
+  });
+
+  it('kostenProKm = kostenPro100km / 100', () => {
+    expect(kostenProKm(0.33, 18)).toBeCloseTo(0.0594);
+  });
+
+  it('kostenProMonat = kostenProKm × km', () => {
+    expect(kostenProMonat(0.33, 18, 1000)).toBeCloseTo(59.4);
+  });
+
+  it('benzinKostenProMonat = (preis × verbrauch / 100) × km', () => {
+    expect(benzinKostenProMonat(1.80, 7.5, 1000)).toBeCloseTo(135.0);
+  });
+
+  it('ersparnisProMonat = benzin - strom', () => {
+    expect(ersparnisProMonat(0.33, 18, 1.80, 7.5, 1000)).toBeCloseTo(75.6);
+  });
+
+  it('negative Ersparnis wenn Strom teurer', () => {
+    expect(ersparnisProMonat(0.80, 24, 1.80, 7.5, 1000)).toBeLessThan(0);
+  });
+});

--- a/frontend/src/utils/ladekostenCalc.ts
+++ b/frontend/src/utils/ladekostenCalc.ts
@@ -1,0 +1,24 @@
+export function kostenPro100km(strompreis: number, verbrauchKwh: number): number {
+  return strompreis * verbrauchKwh;
+}
+
+export function kostenProKm(strompreis: number, verbrauchKwh: number): number {
+  return kostenPro100km(strompreis, verbrauchKwh) / 100;
+}
+
+export function kostenProMonat(strompreis: number, verbrauchKwh: number, kmProMonat: number): number {
+  return kostenProKm(strompreis, verbrauchKwh) * kmProMonat;
+}
+
+export function benzinKostenProMonat(benzinpreis: number, benzinVerbrauch: number, kmProMonat: number): number {
+  return (benzinpreis * benzinVerbrauch / 100) * kmProMonat;
+}
+
+export function ersparnisProMonat(
+  strompreis: number, verbrauchKwh: number,
+  benzinpreis: number, benzinVerbrauch: number,
+  kmProMonat: number
+): number {
+  return benzinKostenProMonat(benzinpreis, benzinVerbrauch, kmProMonat)
+    - kostenProMonat(strompreis, verbrauchKwh, kmProMonat);
+}

--- a/frontend/src/views/EchteReichweiteView.vue
+++ b/frontend/src/views/EchteReichweiteView.vue
@@ -1,0 +1,304 @@
+<template>
+  <div class="min-h-screen bg-gray-50 dark:bg-gray-950">
+    <PublicNav />
+
+    <main class="max-w-3xl mx-auto px-4 py-8">
+      <!-- Hero -->
+      <div class="text-center mb-8">
+        <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2 leading-tight">
+          Echte Reichweite Elektroauto - Real vs. WLTP
+        </h1>
+        <p class="text-gray-500 dark:text-gray-400 text-sm sm:text-base max-w-xl mx-auto">
+          Wie weit fahren E-Autos wirklich? Community-Verbrauchsdaten von echten Fahrern zeigen,
+          wie stark der Unterschied zum WLTP-Laborwert ist.
+        </p>
+      </div>
+
+      <!-- WLTP Erklarung -->
+      <div class="bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800 rounded-xl p-4 mb-6 text-sm text-amber-800 dark:text-amber-300">
+        <strong>Was ist WLTP?</strong> Der WLTP-Wert (Worldwide Harmonised Light Vehicle Test Procedure) ist ein
+        Laborwert unter kontrollierten Bedingungen. In der Praxis weicht der reale Verbrauch je nach Temperatur,
+        Fahrweise und Streckentyp deutlich ab.
+      </div>
+
+      <!-- Loading -->
+      <div v-if="loading" class="flex justify-center py-16">
+        <div class="animate-spin rounded-full h-10 w-10 border-b-2 border-green-500"></div>
+      </div>
+
+      <!-- Model Table -->
+      <div v-if="!loading && models.length > 0">
+        <!-- Strompreis-Eingabe für Kostenspalte -->
+        <div class="flex items-center justify-between mb-4 gap-3 flex-wrap">
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200">
+            {{ models.length }} Modelle im Vergleich
+          </h2>
+          <div class="flex items-center gap-2 text-sm">
+            <label class="text-gray-500 dark:text-gray-400 shrink-0">Strompreis:</label>
+            <input
+              v-model.number="strompreis"
+              type="number"
+              min="0.10"
+              max="0.80"
+              step="0.01"
+              class="w-20 border border-gray-200 dark:border-gray-600 rounded-lg px-2 py-1 text-sm text-right bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+            />
+            <span class="text-gray-400 shrink-0">€/kWh</span>
+          </div>
+        </div>
+
+        <div class="space-y-2">
+          <div
+            v-for="model in sortedModels"
+            :key="`${model.brand}-${model.model}`"
+            class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4"
+          >
+            <div class="flex items-start justify-between gap-3">
+              <div class="min-w-0">
+                <a
+                  :href="`/modelle/${model.brand}/${model.modelUrlSlug}`"
+                  class="text-sm font-semibold text-gray-900 dark:text-gray-100 hover:text-green-600 dark:hover:text-green-400 transition-colors"
+                >
+                  {{ model.brandDisplayName }} {{ model.modelDisplayName }}
+                </a>
+                <div class="text-xs text-gray-400 mt-0.5">
+                  {{ model.logCount.toLocaleString('de-DE') }} Ladevorgänge
+                </div>
+              </div>
+              <div class="text-right shrink-0">
+                <div v-if="model.avgConsumptionKwhPer100km" class="text-base font-bold text-gray-900 dark:text-gray-100">
+                  {{ model.avgConsumptionKwhPer100km.toFixed(1) }} kWh
+                </div>
+                <div v-else class="text-base font-bold text-gray-400">-</div>
+                <div class="text-xs text-gray-400">real / 100 km</div>
+              </div>
+            </div>
+
+            <!-- Bar Visualisierung -->
+            <div v-if="model.avgConsumptionKwhPer100km && model.wltpMidpoint" class="mt-3 space-y-1.5">
+              <!-- Real -->
+              <div class="flex items-center gap-2 text-xs">
+                <span class="w-12 text-gray-500 dark:text-gray-400 shrink-0">Real</span>
+                <div class="flex-1 h-2.5 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
+                  <div
+                    class="h-full bg-green-500 rounded-full"
+                    :style="{ width: barWidth(model.avgConsumptionKwhPer100km) }"
+                  ></div>
+                </div>
+                <span class="w-20 text-right text-gray-600 dark:text-gray-300 font-medium">
+                  {{ formatKosten(model.avgConsumptionKwhPer100km) }} €/100km
+                </span>
+              </div>
+              <!-- WLTP -->
+              <div class="flex items-center gap-2 text-xs">
+                <span class="w-12 text-gray-500 dark:text-gray-400 shrink-0">WLTP</span>
+                <div class="flex-1 h-2.5 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
+                  <div
+                    class="h-full bg-blue-300 dark:bg-blue-600 rounded-full"
+                    :style="{ width: barWidth(model.wltpMidpoint) }"
+                  ></div>
+                </div>
+                <span class="w-20 text-right text-gray-500 dark:text-gray-400">
+                  {{ formatKosten(model.wltpMidpoint) }} €/100km
+                </span>
+              </div>
+            </div>
+
+            <!-- Abweichung Badge -->
+            <div v-if="model.deviationPct !== null" class="mt-2 flex items-center gap-2">
+              <span
+                :class="model.deviationPct <= 0 ? 'bg-green-100 dark:bg-green-900/30 text-green-700 dark:text-green-400' : model.deviationPct <= 25 ? 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400' : 'bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400'"
+                class="inline-flex items-center gap-1 text-xs font-medium px-2 py-0.5 rounded-full"
+              >
+                {{ model.deviationPct >= 0 ? '+' : '' }}{{ model.deviationPct.toFixed(0) }}% {{ model.deviationPct >= 0 ? 'über' : 'unter' }} WLTP
+              </span>
+              <a
+                :href="`/modelle/${model.brand}/${model.modelUrlSlug}`"
+                class="text-xs text-green-600 dark:text-green-400 hover:underline"
+              >
+                Details ansehen
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Info -->
+      <div class="mt-8 space-y-5 text-sm text-gray-600 dark:text-gray-400">
+        <div>
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">
+            Warum weicht die echte Reichweite vom WLTP ab?
+          </h2>
+          <p>
+            WLTP-Tests finden bei 23 Grad, ohne Klimaanlage/Heizung und auf einem definierten Mischzyklus statt.
+            Im Alltag kommen Autobahn (deutlich mehr Verbrauch), Winter (-20 bis -40% durch Heizung + Kaltakkus)
+            und aggressive Fahrweise dazu. Die Community-Werte zeigen den echten Jahresdurchschnitt.
+          </p>
+        </div>
+        <div>
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">
+            Wie werden die Daten erhoben?
+          </h2>
+          <p>
+            Alle Werte kommen von EV-Monitor-Nutzern, die ihre Ladevorgänge und Fahrten dokumentieren.
+            Der Verbrauch wird aus tatsächlich geladenen kWh und gefahrenen km berechnet - nicht vom Bordcomputer.
+            Ausreißer werden per Plausibilitätsprüfung gefiltert.
+          </p>
+        </div>
+        <div>
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">
+            Kann ich meine Daten beisteuern?
+          </h2>
+          <p>
+            Ja - jeder EV-Monitor-Nutzer trägt automatisch zur Community-Statistik bei.
+            Mehr Daten bedeuten präzisere Werte für alle.
+          </p>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="mt-8 bg-gradient-to-br from-gray-900 to-green-900 rounded-xl p-6 text-center">
+        <h2 class="text-lg font-bold text-white mb-2">Deine echte Reichweite herausfinden</h2>
+        <p class="text-gray-300 text-sm mb-4">
+          Trag deine Ladevorgänge ein - EV Monitor berechnet deinen realen Verbrauch und deine echte Reichweite automatisch.
+        </p>
+        <a
+          href="/register"
+          class="inline-flex items-center gap-2 bg-green-500 hover:bg-green-400 text-white font-semibold px-6 py-3 rounded-lg transition-colors text-sm"
+        >
+          Kostenlos starten
+          <ArrowRightIcon class="h-4 w-4" />
+        </a>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useHead } from '@unhead/vue';
+import { ArrowRightIcon } from '@heroicons/vue/24/outline';
+import PublicNav from '../components/shared/PublicNav.vue';
+import { getTopModels, type TopModelPreview } from '../api/publicModelService';
+
+useHead({
+  title: 'Echte Reichweite Elektroauto - Real vs. WLTP Vergleich | EV Monitor',
+  meta: [
+    {
+      name: 'description',
+      content: 'Wie weit fahren Elektroautos wirklich? Real-Verbrauch vs. WLTP für Tesla, VW ID.4, BMW iX und mehr - aus echten Fahrdaten der EV-Monitor-Community.'
+    },
+    { property: 'og:title', content: 'Echte Reichweite Elektroauto - Real vs. WLTP | EV Monitor' },
+    { property: 'og:description', content: 'Community-Verbrauchsdaten zeigen die echte Reichweite von Elektroautos im Alltag - nicht den WLTP-Laborwert.' }
+  ],
+  link: [{ rel: 'canonical', href: 'https://ev-monitor.net/echte-reichweite' }],
+  script: [
+    {
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'Article',
+        headline: 'Echte Reichweite Elektroautos - Community-Verbrauchsdaten',
+        description: 'Realer Verbrauch vs. WLTP für die meistgefahrenen Elektroautos - aus Fahrdaten echter EV-Monitor-Nutzer',
+        url: 'https://ev-monitor.net/echte-reichweite',
+        author: { '@type': 'Person', name: 'Sebastian Ihle' },
+        publisher: { '@type': 'Organization', name: 'EV Monitor', url: 'https://ev-monitor.net' },
+        datePublished: '2026-04-30',
+        breadcrumb: {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'EV Monitor', item: 'https://ev-monitor.net' },
+            { '@type': 'ListItem', position: 2, name: 'Echte Reichweite', item: 'https://ev-monitor.net/echte-reichweite' }
+          ]
+        }
+      })
+    },
+    {
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        mainEntity: [
+          {
+            '@type': 'Question',
+            name: 'Warum weicht die echte Reichweite vom WLTP ab?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'WLTP-Tests finden bei 23 Grad, ohne Klimaanlage/Heizung und auf einem definierten Mischzyklus statt. Im Alltag kommen Autobahn, Winter (-20 bis -40% durch Heizung + Kaltakkus) und aggressive Fahrweise dazu. Die Community-Werte zeigen den echten Jahresdurchschnitt.'
+            }
+          },
+          {
+            '@type': 'Question',
+            name: 'Wie werden die Daten erhoben?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'Alle Werte kommen von EV-Monitor-Nutzern, die ihre Ladevorgänge und Fahrten dokumentieren. Der Verbrauch wird aus tatsächlich geladenen kWh und gefahrenen km berechnet - nicht vom Bordcomputer. Ausreißer werden per Plausibilitätsprüfung gefiltert.'
+            }
+          },
+          {
+            '@type': 'Question',
+            name: 'Kann ich meine Daten beisteuern?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'Ja - jeder EV-Monitor-Nutzer trägt automatisch zur Community-Statistik bei. Mehr Daten bedeuten präzisere Werte für alle.'
+            }
+          }
+        ]
+      })
+    }
+  ]
+});
+
+interface EnrichedModel extends TopModelPreview {
+  wltpMidpoint: number | null;
+  deviationPct: number | null;
+}
+
+const loading = ref(true);
+const models = ref<EnrichedModel[]>([]);
+const strompreis = ref(0.33);
+
+const maxConsumption = computed(() => {
+  const vals = models.value
+    .map(m => m.avgConsumptionKwhPer100km ?? 0)
+    .filter(v => v > 0);
+  return vals.length > 0 ? Math.max(...vals) : 30;
+});
+
+const sortedModels = computed(() =>
+  [...models.value]
+    .filter(m => m.avgConsumptionKwhPer100km !== null && m.logCount >= 10)
+    .sort((a, b) => (a.deviationPct ?? 999) - (b.deviationPct ?? 999))
+);
+
+function barWidth(value: number | null): string {
+  if (!value) return '0%';
+  return `${Math.min(100, (value / (maxConsumption.value * 1.1)) * 100).toFixed(1)}%`;
+}
+
+function formatKosten(kwhPer100km: number | null): string {
+  if (!kwhPer100km) return '-';
+  return (kwhPer100km * strompreis.value).toFixed(2);
+}
+
+onMounted(async () => {
+  try {
+    const raw = await getTopModels(50);
+    models.value = raw.map(m => {
+      const wltpMidpoint =
+        m.minWltpConsumptionKwhPer100km && m.maxWltpConsumptionKwhPer100km
+          ? (m.minWltpConsumptionKwhPer100km + m.maxWltpConsumptionKwhPer100km) / 2
+          : m.minWltpConsumptionKwhPer100km ?? m.maxWltpConsumptionKwhPer100km ?? null;
+
+      const deviationPct =
+        m.avgConsumptionKwhPer100km && wltpMidpoint && wltpMidpoint > 0
+          ? ((m.avgConsumptionKwhPer100km - wltpMidpoint) / wltpMidpoint) * 100
+          : null;
+
+      return { ...m, wltpMidpoint, deviationPct };
+    });
+  } finally {
+    loading.value = false;
+  }
+});
+</script>

--- a/frontend/src/views/ElektroautoKostenView.vue
+++ b/frontend/src/views/ElektroautoKostenView.vue
@@ -1,0 +1,327 @@
+<template>
+  <div class="min-h-screen bg-gray-50 dark:bg-gray-950">
+    <PublicNav />
+
+    <main class="max-w-3xl mx-auto px-4 py-8">
+      <!-- Hero -->
+      <div class="text-center mb-8">
+        <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2 leading-tight">
+          Elektroauto Kosten pro km - echte Daten
+        </h1>
+        <p class="text-gray-500 dark:text-gray-400 text-sm sm:text-base max-w-xl mx-auto">
+          Wieviel kostet ein Elektroauto pro Kilometer? Stromkosten, Verbrauch und Vergleich zum Benziner -
+          berechnet aus realen Fahrdaten.
+        </p>
+      </div>
+
+      <!-- Strompreis-Eingabe -->
+      <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 mb-6">
+        <div class="flex items-center gap-4 flex-wrap">
+          <span class="text-sm font-medium text-gray-700 dark:text-gray-300 shrink-0">Dein Strompreis:</span>
+          <div class="flex items-center gap-2 flex-1">
+            <input
+              v-model.number="strompreis"
+              type="range"
+              min="0.10"
+              max="0.70"
+              step="0.01"
+              class="flex-1 accent-green-500"
+            />
+            <div class="flex items-center gap-1">
+              <input
+                v-model.number="strompreis"
+                type="number"
+                min="0.10"
+                max="0.70"
+                step="0.01"
+                class="w-16 border border-gray-200 dark:border-gray-600 rounded-lg px-2 py-1 text-sm text-right bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+              />
+              <span class="text-sm text-gray-500 dark:text-gray-400">€/kWh</span>
+            </div>
+          </div>
+        </div>
+        <p class="text-xs text-gray-400 mt-2">
+          Heimladung DE: ca. 28-40 ct/kWh - Öffentliche Schnelllader: 50-80 ct/kWh
+        </p>
+      </div>
+
+      <!-- Loading -->
+      <div v-if="loading" class="flex justify-center py-16">
+        <div class="animate-spin rounded-full h-10 w-10 border-b-2 border-green-500"></div>
+      </div>
+
+      <!-- Model List -->
+      <div v-if="!loading && models.length > 0">
+        <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-4">
+          Kosten pro 100 km nach Modell
+        </h2>
+        <div class="space-y-2 mb-8">
+          <div
+            v-for="(model, index) in topModels"
+            :key="`${model.brand}-${model.model}`"
+            class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 flex items-center gap-4"
+          >
+            <div class="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold shrink-0"
+              :class="index === 0 ? 'bg-yellow-100 dark:bg-yellow-900/30 text-yellow-700 dark:text-yellow-400' : index === 1 ? 'bg-gray-100 dark:bg-gray-700 text-gray-600 dark:text-gray-300' : index === 2 ? 'bg-orange-100 dark:bg-orange-900/30 text-orange-700 dark:text-orange-400' : 'bg-gray-50 dark:bg-gray-700/50 text-gray-400'"
+            >
+              {{ index + 1 }}
+            </div>
+
+            <div class="flex-1 min-w-0">
+              <a
+                :href="`/modelle/${model.brand}/${model.modelUrlSlug}`"
+                class="text-sm font-medium text-gray-900 dark:text-gray-100 hover:text-green-600 dark:hover:text-green-400 transition-colors block truncate"
+              >
+                {{ model.brandDisplayName }} {{ model.modelDisplayName }}
+              </a>
+              <div class="text-xs text-gray-400 mt-0.5">
+                {{ model.avgConsumptionKwhPer100km?.toFixed(1) ?? '?' }} kWh/100km real
+                <span v-if="model.minWltpConsumptionKwhPer100km" class="ml-2 text-gray-300 dark:text-gray-600">
+                  (WLTP: {{ model.minWltpConsumptionKwhPer100km.toFixed(1) }})
+                </span>
+              </div>
+            </div>
+
+            <div class="text-right shrink-0">
+              <div class="text-base font-bold text-green-600 dark:text-green-400">
+                {{ formatKosten(model.avgConsumptionKwhPer100km) }}
+              </div>
+              <div class="text-xs text-gray-400">€ / 100 km</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Kosten-Vergleich Tabelle -->
+      <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-5 mb-8">
+        <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-4">
+          Elektro vs. Benziner vs. Diesel - Kosten pro 100 km
+        </h2>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="text-left text-xs text-gray-500 dark:text-gray-400 border-b border-gray-100 dark:border-gray-700">
+                <th class="pb-2 font-medium">Antrieb</th>
+                <th class="pb-2 font-medium text-right">Verbrauch</th>
+                <th class="pb-2 font-medium text-right">Preis</th>
+                <th class="pb-2 font-medium text-right">Kosten/100km</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-50 dark:divide-gray-700">
+              <tr v-for="row in vergleichsTabelle" :key="row.label">
+                <td class="py-2.5 font-medium" :class="row.highlight ? 'text-green-600 dark:text-green-400' : 'text-gray-700 dark:text-gray-300'">
+                  {{ row.label }}
+                </td>
+                <td class="py-2.5 text-right text-gray-600 dark:text-gray-400">{{ row.verbrauch }}</td>
+                <td class="py-2.5 text-right text-gray-600 dark:text-gray-400">{{ row.preis }}</td>
+                <td class="py-2.5 text-right font-bold" :class="row.highlight ? 'text-green-600 dark:text-green-400' : 'text-gray-700 dark:text-gray-300'">
+                  {{ row.kosten }}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="text-xs text-gray-400 mt-3">
+          Benzin/Diesel: Durchschnittspreis DE 2025 (ca. 1,80 €/L Benzin, 1,65 €/L Diesel).
+          E-Auto: Dein eingestellter Strompreis ({{ strompreis.toFixed(2) }} €/kWh).
+        </p>
+      </div>
+
+      <!-- FAQ -->
+      <div class="space-y-5 text-sm text-gray-600 dark:text-gray-400 mb-8">
+        <div>
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">
+            Was kostet ein Elektroauto pro Kilometer?
+          </h2>
+          <p>
+            Bei einem Haushaltsstrompreis von 33 ct/kWh und einem realen Verbrauch von 18 kWh/100 km
+            kostet ein E-Auto <strong>5,94 € pro 100 km</strong> bzw. rund <strong>6 Cent pro km</strong>.
+            Zum Vergleich: ein Benziner mit 7 L/100 km bei 1,80 €/L kostet 12,60 € pro 100 km.
+          </p>
+        </div>
+        <div>
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">
+            Welche Gesamtkosten hat ein E-Auto gegenüber einem Benziner?
+          </h2>
+          <p>
+            Die reine Energiekosten-Ersparnis liegt bei durchschnittlich 6-8 Cent/km - bei 15.000 km/Jahr
+            sind das 900-1.200 € pro Jahr. Hinzu kommen geringere Wartungskosten (kein Ölwechsel,
+            weniger Verschleiß). Die Anschaffungskosten sind höher, gleichen sich je nach Modell
+            nach 3-6 Jahren aus.
+          </p>
+        </div>
+        <div>
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">
+            Lohnt sich ein E-Auto wenn ich viel auf der Autobahn fahre?
+          </h2>
+          <p>
+            Bei viel Autobahnanteil steigt der Verbrauch auf 22-28 kWh/100 km - das entspricht
+            7-9 € pro 100 km bei 33 ct/kWh, oder bis zu 14-18 € wenn hauptsächlich Schnelllader
+            genutzt werden. Der Vorteil gegenüber Benzinern ist dann geringer, bleibt aber oft positiv.
+          </p>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="bg-gradient-to-br from-gray-900 to-green-900 rounded-xl p-6 text-center">
+        <h2 class="text-lg font-bold text-white mb-2">Deine echten Kosten pro km</h2>
+        <p class="text-gray-300 text-sm mb-4">
+          Diese Zahlen sind Durchschnittswerte. Deine echten Kosten hangen von deinem Fahrverhalten,
+          deiner Route und deinem Stromtarif ab. EV Monitor berechnet sie exakt aus deinen Daten.
+        </p>
+        <a
+          href="/register"
+          class="inline-flex items-center gap-2 bg-green-500 hover:bg-green-400 text-white font-semibold px-6 py-3 rounded-lg transition-colors text-sm"
+        >
+          Kostenlos starten
+          <ArrowRightIcon class="h-4 w-4" />
+        </a>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue';
+import { useHead } from '@unhead/vue';
+import { ArrowRightIcon } from '@heroicons/vue/24/outline';
+import PublicNav from '../components/shared/PublicNav.vue';
+import { getTopModels, type TopModelPreview } from '../api/publicModelService';
+
+useHead({
+  title: 'Elektroauto Kosten pro km - echte Verbrauchsdaten | EV Monitor',
+  meta: [
+    {
+      name: 'description',
+      content: 'Wieviel kostet ein Elektroauto pro Kilometer wirklich? Stromkosten pro 100 km für Tesla, VW ID, BMW und mehr - mit echten Community-Verbrauchsdaten und Benziner-Vergleich.'
+    },
+    { property: 'og:title', content: 'Elektroauto Kosten pro km - Real-Daten | EV Monitor' },
+    { property: 'og:description', content: 'Echte Ladekosten pro 100 km für die meistgefahrenen E-Autos - aus Community-Daten, mit Benziner-Vergleich.' }
+  ],
+  link: [{ rel: 'canonical', href: 'https://ev-monitor.net/elektroauto-kosten-pro-km' }],
+  script: [
+    {
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'Article',
+        headline: 'Elektroauto Kosten pro km - echte Verbrauchsdaten',
+        description: 'Stromkosten pro 100 km für die meistgefahrenen Elektroautos aus echten Fahrdaten',
+        url: 'https://ev-monitor.net/elektroauto-kosten-pro-km',
+        author: { '@type': 'Person', name: 'Sebastian Ihle' },
+        publisher: { '@type': 'Organization', name: 'EV Monitor', url: 'https://ev-monitor.net' },
+        datePublished: '2026-04-30',
+        breadcrumb: {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'EV Monitor', item: 'https://ev-monitor.net' },
+            { '@type': 'ListItem', position: 2, name: 'Kosten pro km', item: 'https://ev-monitor.net/elektroauto-kosten-pro-km' }
+          ]
+        }
+      })
+    },
+    {
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        mainEntity: [
+          {
+            '@type': 'Question',
+            name: 'Was kostet ein Elektroauto pro Kilometer?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'Bei einem Haushaltsstrompreis von 33 ct/kWh und einem realen Verbrauch von 18 kWh/100 km kostet ein E-Auto 5,94 € pro 100 km bzw. rund 6 Cent pro km. Zum Vergleich: ein Benziner mit 7 L/100 km bei 1,80 €/L kostet 12,60 € pro 100 km.'
+            }
+          },
+          {
+            '@type': 'Question',
+            name: 'Welche Gesamtkosten hat ein E-Auto gegenüber einem Benziner?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'Die reine Energiekosten-Ersparnis liegt bei durchschnittlich 6-8 Cent/km - bei 15.000 km/Jahr sind das 900-1.200 € pro Jahr. Hinzu kommen geringere Wartungskosten (kein Ölwechsel, weniger Verschleiß). Die Anschaffungskosten sind höher, gleichen sich je nach Modell nach 3-6 Jahren aus.'
+            }
+          },
+          {
+            '@type': 'Question',
+            name: 'Lohnt sich ein E-Auto wenn ich viel auf der Autobahn fahre?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'Bei viel Autobahnanteil steigt der Verbrauch auf 22-28 kWh/100 km - das entspricht 7-9 € pro 100 km bei 33 ct/kWh, oder bis zu 14-18 € wenn hauptsächlich Schnelllader genutzt werden. Der Vorteil gegenüber Benzinern ist dann geringer, bleibt aber oft positiv.'
+            }
+          }
+        ]
+      })
+    }
+  ]
+});
+
+const loading = ref(true);
+const models = ref<TopModelPreview[]>([]);
+const strompreis = ref(0.33);
+
+const topModels = computed(() =>
+  [...models.value]
+    .filter(m => m.avgConsumptionKwhPer100km !== null && m.logCount >= 10)
+    .sort((a, b) => (a.avgConsumptionKwhPer100km ?? 99) - (b.avgConsumptionKwhPer100km ?? 99))
+    .slice(0, 15)
+);
+
+const vergleichsTabelle = computed(() => [
+  {
+    label: 'E-Auto (effizient, z.B. Tesla M3)',
+    verbrauch: '15 kWh/100km',
+    preis: `${strompreis.value.toFixed(2)} €/kWh`,
+    kosten: `${(15 * strompreis.value).toFixed(2)} €`,
+    highlight: true
+  },
+  {
+    label: 'E-Auto (Durchschnitt)',
+    verbrauch: '19 kWh/100km',
+    preis: `${strompreis.value.toFixed(2)} €/kWh`,
+    kosten: `${(19 * strompreis.value).toFixed(2)} €`,
+    highlight: true
+  },
+  {
+    label: 'E-Auto (SUV)',
+    verbrauch: '24 kWh/100km',
+    preis: `${strompreis.value.toFixed(2)} €/kWh`,
+    kosten: `${(24 * strompreis.value).toFixed(2)} €`,
+    highlight: true
+  },
+  {
+    label: 'Benziner (Kompakt)',
+    verbrauch: '6.5 L/100km',
+    preis: '1,80 €/L',
+    kosten: '11,70 €',
+    highlight: false
+  },
+  {
+    label: 'Benziner (SUV)',
+    verbrauch: '9.0 L/100km',
+    preis: '1,80 €/L',
+    kosten: '16,20 €',
+    highlight: false
+  },
+  {
+    label: 'Diesel (Kompakt)',
+    verbrauch: '5.5 L/100km',
+    preis: '1,65 €/L',
+    kosten: '9,08 €',
+    highlight: false
+  },
+]);
+
+function formatKosten(kwhPer100km: number | null): string {
+  if (!kwhPer100km) return '-';
+  return (kwhPer100km * strompreis.value).toFixed(2);
+}
+
+onMounted(async () => {
+  try {
+    models.value = await getTopModels(50);
+  } finally {
+    loading.value = false;
+  }
+});
+</script>

--- a/frontend/src/views/LadekostenRechnerView.vue
+++ b/frontend/src/views/LadekostenRechnerView.vue
@@ -1,0 +1,226 @@
+<template>
+  <div class="min-h-screen bg-gray-50 dark:bg-gray-950">
+    <PublicNav />
+
+    <main class="max-w-2xl mx-auto px-4 py-8">
+      <div class="text-center mb-8">
+        <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2 leading-tight">
+          Ladekosten Rechner Elektroauto
+        </h1>
+        <p class="text-gray-500 dark:text-gray-400 text-sm sm:text-base max-w-xl mx-auto">
+          Berechne was dich dein E-Auto pro Monat, pro 100&nbsp;km und im Vergleich zum Benziner wirklich kostet.
+        </p>
+      </div>
+
+      <div class="bg-white dark:bg-gray-800 rounded-xl shadow-sm border border-gray-100 dark:border-gray-700 p-5 mb-6">
+        <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-4">Deine Eingaben</h2>
+        <div class="space-y-5">
+          <div>
+            <label for="strompreis" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Strompreis</label>
+            <div class="flex items-center gap-3">
+              <input v-model.number="strompreis" type="range" min="0.10" max="0.60" step="0.01" class="flex-1 accent-green-500" aria-labelledby="strompreis" />
+              <div class="flex items-center gap-1 w-24">
+                <input id="strompreis" v-model.number="strompreis" type="number" min="0.10" max="0.60" step="0.01" class="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-2 py-1.5 text-sm text-right bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100" />
+                <span class="text-sm text-gray-500 dark:text-gray-400 shrink-0">€/kWh</span>
+              </div>
+            </div>
+            <div class="flex justify-between text-xs text-gray-400 mt-0.5 px-0.5"><span>0,10 €</span><span>0,60 €</span></div>
+          </div>
+
+          <div>
+            <label for="verbrauch" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Durchschnittsverbrauch</label>
+            <div class="flex items-center gap-3">
+              <input v-model.number="verbrauch" type="range" min="10" max="35" step="0.5" class="flex-1 accent-green-500" aria-labelledby="verbrauch" />
+              <div class="flex items-center gap-1 w-28">
+                <input id="verbrauch" v-model.number="verbrauch" type="number" min="10" max="35" step="0.5" class="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-2 py-1.5 text-sm text-right bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100" />
+                <span class="text-sm text-gray-500 dark:text-gray-400 shrink-0">kWh/100</span>
+              </div>
+            </div>
+            <div class="flex justify-between text-xs text-gray-400 mt-0.5 px-0.5"><span>10</span><span>35</span></div>
+          </div>
+
+          <div>
+            <label for="km-monat" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Fahrleistung pro Monat</label>
+            <div class="flex items-center gap-3">
+              <input v-model.number="kmProMonat" type="range" min="200" max="4000" step="50" class="flex-1 accent-green-500" aria-labelledby="km-monat" />
+              <div class="flex items-center gap-1 w-24">
+                <input id="km-monat" v-model.number="kmProMonat" type="number" min="200" max="4000" step="50" class="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-2 py-1.5 text-sm text-right bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100" />
+                <span class="text-sm text-gray-500 dark:text-gray-400 shrink-0">km</span>
+              </div>
+            </div>
+            <div class="flex justify-between text-xs text-gray-400 mt-0.5 px-0.5"><span>200 km</span><span>4.000 km</span></div>
+          </div>
+
+          <div class="border-t border-gray-100 dark:border-gray-700 pt-4">
+            <button
+              @click="showBenziner = !showBenziner"
+              :aria-expanded="showBenziner"
+              class="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+            >
+              <ChevronDownIcon v-if="showBenziner" class="h-4 w-4" />
+              <ChevronRightIcon v-else class="h-4 w-4" />
+              Vergleich mit Benziner {{ showBenziner ? 'ausblenden' : 'anzeigen' }}
+            </button>
+            <div v-if="showBenziner" class="mt-3 space-y-4">
+              <div>
+                <label for="benzinpreis" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Benzinpreis</label>
+                <div class="flex items-center gap-3">
+                  <input v-model.number="benzinpreis" type="range" min="1.20" max="2.50" step="0.01" class="flex-1 accent-orange-400" aria-labelledby="benzinpreis" />
+                  <div class="flex items-center gap-1 w-24">
+                    <input id="benzinpreis" v-model.number="benzinpreis" type="number" min="1.20" max="2.50" step="0.01" class="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-2 py-1.5 text-sm text-right bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100" />
+                    <span class="text-sm text-gray-500 dark:text-gray-400 shrink-0">€/L</span>
+                  </div>
+                </div>
+              </div>
+              <div>
+                <label for="benzin-verbrauch" class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Benzinverbrauch</label>
+                <div class="flex items-center gap-3">
+                  <input v-model.number="benzinVerbrauch" type="range" min="4" max="15" step="0.5" class="flex-1 accent-orange-400" aria-labelledby="benzin-verbrauch" />
+                  <div class="flex items-center gap-1 w-28">
+                    <input id="benzin-verbrauch" v-model.number="benzinVerbrauch" type="number" min="4" max="15" step="0.5" class="w-full border border-gray-200 dark:border-gray-600 rounded-lg px-2 py-1.5 text-sm text-right bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100" />
+                    <span class="text-sm text-gray-500 dark:text-gray-400 shrink-0">L/100km</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="grid grid-cols-2 gap-3 mb-6">
+        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 text-center">
+          <div class="text-2xl font-bold text-green-600 dark:text-green-400">{{ formatEur(computed_kostenPro100km) }}</div>
+          <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">Kosten pro 100 km</div>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 text-center">
+          <div class="text-2xl font-bold text-green-600 dark:text-green-400">{{ formatEur(computed_kostenProMonat) }}</div>
+          <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">Ladekosten/Monat</div>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 text-center">
+          <div class="text-2xl font-bold text-green-600 dark:text-green-400">{{ formatEur(computed_kostenProKm) }}</div>
+          <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">Kosten pro km</div>
+        </div>
+        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-4 text-center">
+          <div class="text-2xl font-bold text-green-600 dark:text-green-400">{{ formatEur(computed_kostenProMonat * 12) }}</div>
+          <div class="text-xs text-gray-500 dark:text-gray-400 mt-1">Ladekosten/Jahr</div>
+        </div>
+      </div>
+
+      <div v-if="showBenziner" class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-5 mb-6">
+        <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-4">Vergleich mit Benziner</h2>
+        <div class="space-y-3">
+          <div class="flex justify-between items-center text-sm">
+            <span class="text-gray-600 dark:text-gray-400">Benzinkosten pro Monat</span>
+            <span class="font-semibold text-orange-500">{{ formatEur(computed_benzinProMonat) }}</span>
+          </div>
+          <div class="flex justify-between items-center text-sm">
+            <span class="text-gray-600 dark:text-gray-400">Ladekosten pro Monat</span>
+            <span class="font-semibold text-green-600 dark:text-green-400">{{ formatEur(computed_kostenProMonat) }}</span>
+          </div>
+          <div class="border-t border-gray-100 dark:border-gray-700 pt-3 flex justify-between items-center">
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Ersparnis pro Monat</span>
+            <span :class="computed_ersparnisMonat >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-500'" class="text-lg font-bold">
+              {{ computed_ersparnisMonat >= 0 ? '+' : '' }}{{ formatEur(computed_ersparnisMonat) }}
+            </span>
+          </div>
+          <div class="flex justify-between items-center">
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Ersparnis pro Jahr</span>
+            <span :class="computed_ersparnisMonat >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-500'" class="text-xl font-bold">
+              {{ computed_ersparnisMonat >= 0 ? '+' : '' }}{{ formatEur(computed_ersparnisMonat * 12) }}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div class="bg-blue-50 dark:bg-blue-950/30 border border-blue-100 dark:border-blue-900 rounded-xl p-4 mb-6 text-sm text-blue-700 dark:text-blue-300">
+        <p><strong>Hinweis:</strong> Der Rechner gibt einen Schätzwert auf Basis der eingegebenen Durchschnittswerte. Der tatsächliche Verbrauch schwankt je nach Fahrweise, Temperatur und Streckentyp. Mit einem Ladetagebuch siehst du deine <em>echten</em> Kosten.</p>
+      </div>
+
+      <div class="bg-gradient-to-br from-gray-900 to-green-900 rounded-xl p-6 text-center">
+        <h2 class="text-lg font-bold text-white mb-2">Echte Kosten statt Schätzwerte</h2>
+        <p class="text-gray-300 text-sm mb-4">EV Monitor trackt meine Ladekosten automatisch - mit echtem Verbrauch, echten Preisen, echter Reichweite. Kostenlos, keine Kreditkarte nötig.</p>
+        <a href="/register" class="inline-flex items-center gap-2 bg-green-500 hover:bg-green-400 text-white font-semibold px-6 py-3 rounded-lg transition-colors text-sm">
+          Kostenlos starten
+          <ArrowRightIcon class="h-4 w-4" />
+        </a>
+      </div>
+
+      <div class="mt-10 space-y-6 text-sm text-gray-600 dark:text-gray-400">
+        <div>
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-2">Wie berechne ich die Ladekosten meines Elektroautos?</h2>
+          <p>Die Formel ist einfach: <strong>Ladekosten pro 100 km = Verbrauch (kWh/100 km) × Strompreis (€/kWh)</strong>. Bei einem Verbrauch von 18 kWh/100 km und einem Strompreis von 0,33 €/kWh kostet dich jede 100 km exakt 5,94 €. Zum Vergleich: ein Benziner mit 7 L/100 km bei 1,80 €/L kostet 12,60 € pro 100 km.</p>
+        </div>
+        <div>
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-2">Welchen Strompreis soll ich verwenden?</h2>
+          <p>Wenn du hauptsächlich zu Hause lädst, ist dein Haushaltsstrompreis der richtige Wert - in Deutschland liegt er aktuell bei etwa 28-40 Cent/kWh. Nutzt du öfter öffentliche Schnelllader, liegt der Preis je nach Anbieter zwischen 50 und 80 Cent/kWh. Viele EV-Fahrer laden zu 80-90% zuhause.</p>
+        </div>
+        <div>
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-2">Warum weicht mein realer Verbrauch vom WLTP-Wert ab?</h2>
+          <p>Der WLTP-Wert ist ein Laborwert unter Idealbedingungen. In der Praxis beeinflussen Temperatur (-30% im Winter), Fahrweise (Autobahn deutlich mehr als Stadtverkehr) und Klimaanlage den Verbrauch erheblich. Die Community-Daten von EV Monitor zeigen die echten Werte für jedes Modell.</p>
+        </div>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed } from 'vue';
+import { useHead } from '@unhead/vue';
+import { ArrowRightIcon, ChevronDownIcon, ChevronRightIcon } from '@heroicons/vue/24/outline';
+import PublicNav from '../components/shared/PublicNav.vue';
+import { kostenPro100km, kostenProKm, kostenProMonat, benzinKostenProMonat, ersparnisProMonat } from '../utils/ladekostenCalc';
+
+useHead({
+  title: 'Ladekosten Rechner Elektroauto - Kosten pro km & Monat berechnen | EV Monitor',
+  meta: [
+    { name: 'description', content: 'Kostenloser Ladekosten-Rechner für Elektroautos: Berechne deine Ladekosten pro 100 km, pro Monat und im Vergleich zum Benziner. Mit echten Community-Verbrauchswerten.' },
+    { property: 'og:title', content: 'Ladekosten Rechner Elektroauto | EV Monitor' },
+    { property: 'og:description', content: 'Ladekosten pro 100 km, Monat und Jahr berechnen - kostenlos und ohne Anmeldung.' }
+  ],
+  link: [{ rel: 'canonical', href: 'https://ev-monitor.net/ladekosten-rechner' }],
+  script: [
+    {
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify([
+        {
+          '@context': 'https://schema.org',
+          '@type': 'WebApplication',
+          name: 'EV Monitor Ladekosten Rechner',
+          description: 'Kostenloser Rechner für Ladekosten von Elektroautos - pro km, Monat und im Vergleich zum Benziner',
+          url: 'https://ev-monitor.net/ladekosten-rechner',
+          applicationCategory: 'UtilityApplication',
+          featureList: ['Ladekosten pro 100 km', 'Monatliche Ladekosten', 'Jahreskosten', 'Benziner-Vergleich', 'Ersparnis-Berechnung'],
+          offers: { '@type': 'Offer', price: '0', priceCurrency: 'EUR' },
+          breadcrumb: { '@type': 'BreadcrumbList', itemListElement: [{ '@type': 'ListItem', position: 1, name: 'EV Monitor', item: 'https://ev-monitor.net' }, { '@type': 'ListItem', position: 2, name: 'Ladekosten Rechner', item: 'https://ev-monitor.net/ladekosten-rechner' }] }
+        },
+        {
+          '@context': 'https://schema.org',
+          '@type': 'FAQPage',
+          mainEntity: [
+            { '@type': 'Question', name: 'Wie berechne ich die Ladekosten meines Elektroautos?', acceptedAnswer: { '@type': 'Answer', text: 'Ladekosten pro 100 km = Verbrauch (kWh/100 km) × Strompreis (€/kWh). Bei 18 kWh/100 km und 0,33 €/kWh kostet dich jede 100 km exakt 5,94 €.' } },
+            { '@type': 'Question', name: 'Welchen Strompreis soll ich verwenden?', acceptedAnswer: { '@type': 'Answer', text: 'Bei Heimladung deinen Haushaltsstrompreis (DE: 28-40 Cent/kWh). Bei öffentlichen Schnellladern 50-80 Cent/kWh. Die meisten EV-Fahrer laden zu 80-90% zuhause.' } },
+            { '@type': 'Question', name: 'Warum weicht mein realer Verbrauch vom WLTP-Wert ab?', acceptedAnswer: { '@type': 'Answer', text: 'Der WLTP-Wert ist ein Laborwert. Temperatur, Fahrweise und Klimaanlage beeinflussen den Verbrauch erheblich - bis zu -30% im Winter.' } }
+          ]
+        }
+      ])
+    }
+  ]
+});
+
+const strompreis = ref(0.33);
+const verbrauch = ref(18.0);
+const kmProMonat = ref(1000);
+const benzinpreis = ref(1.85);
+const benzinVerbrauch = ref(7.5);
+const showBenziner = ref(false);
+
+const computed_kostenPro100km = computed(() => kostenPro100km(strompreis.value, verbrauch.value));
+const computed_kostenProKm = computed(() => kostenProKm(strompreis.value, verbrauch.value));
+const computed_kostenProMonat = computed(() => kostenProMonat(strompreis.value, verbrauch.value, kmProMonat.value));
+const computed_benzinProMonat = computed(() => benzinKostenProMonat(benzinpreis.value, benzinVerbrauch.value, kmProMonat.value));
+const computed_ersparnisMonat = computed(() => ersparnisProMonat(strompreis.value, verbrauch.value, benzinpreis.value, benzinVerbrauch.value, kmProMonat.value));
+
+function formatEur(value: number): string {
+  return value.toLocaleString('de-DE', { style: 'currency', currency: 'EUR', minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+</script>

--- a/frontend/src/views/LadetagebuchView.vue
+++ b/frontend/src/views/LadetagebuchView.vue
@@ -1,0 +1,252 @@
+<template>
+  <div class="min-h-screen bg-gray-50 dark:bg-gray-950">
+    <PublicNav />
+
+    <main class="max-w-2xl mx-auto px-4 py-8">
+      <!-- Hero -->
+      <div class="text-center mb-8">
+        <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2 leading-tight">
+          Digitales Ladetagebuch fur dein Elektroauto
+        </h1>
+        <p class="text-gray-500 dark:text-gray-400 text-sm sm:text-base max-w-xl mx-auto">
+          Alle Ladevorgange an einem Ort - Kosten, Verbrauch, Reichweite und SoH auf einen Blick.
+          Kostenlos, ohne Kreditkarte.
+        </p>
+        <div class="mt-5">
+          <a
+            href="/register"
+            class="inline-flex items-center gap-2 bg-green-500 hover:bg-green-400 text-white font-semibold px-6 py-3 rounded-lg transition-colors text-sm"
+          >
+            Ladetagebuch starten
+            <ArrowRightIcon class="h-4 w-4" />
+          </a>
+          <p class="text-xs text-gray-400 mt-2">Kostenlos - kein Abo notwendig</p>
+        </div>
+      </div>
+
+      <!-- Feature Cards -->
+      <div class="space-y-4 mb-10">
+        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-5 flex gap-4">
+          <div class="shrink-0 w-10 h-10 bg-green-100 dark:bg-green-900/30 rounded-lg flex items-center justify-center">
+            <BoltIcon class="h-5 w-5 text-green-600 dark:text-green-400" />
+          </div>
+          <div>
+            <h2 class="text-sm font-semibold text-gray-800 dark:text-gray-200 mb-1">Jeden Ladevorgang erfassen</h2>
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+              Manuell oder automatisch per AutoSync (Tesla, VW, Skoda, SEAT, CUPRA und mehr).
+              SoC, kWh, Kosten, Ladeort - alles wird gespeichert.
+            </p>
+          </div>
+        </div>
+
+        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-5 flex gap-4">
+          <div class="shrink-0 w-10 h-10 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center">
+            <ChartBarIcon class="h-5 w-5 text-blue-600 dark:text-blue-400" />
+          </div>
+          <div>
+            <h2 class="text-sm font-semibold text-gray-800 dark:text-gray-200 mb-1">Verbrauch und Kosten im Blick</h2>
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+              Dashboard mit echtem Verbrauch (kWh/100 km), Kosten pro km, monatlicher Uberblick.
+              Kein Raten mehr - nur Fakten aus deinen eigenen Daten.
+            </p>
+          </div>
+        </div>
+
+        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-5 flex gap-4">
+          <div class="shrink-0 w-10 h-10 bg-purple-100 dark:bg-purple-900/30 rounded-lg flex items-center justify-center">
+            <ArrowTrendingUpIcon class="h-5 w-5 text-purple-600 dark:text-purple-400" />
+          </div>
+          <div>
+            <h2 class="text-sm font-semibold text-gray-800 dark:text-gray-200 mb-1">Echte Reichweite statt WLTP</h2>
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+              Sehe auf Basis deiner gefahrenen km und geladenen kWh, wie weit dein Akku wirklich tragt -
+              nicht der Laborwert des Herstellers.
+            </p>
+          </div>
+        </div>
+
+        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-5 flex gap-4">
+          <div class="shrink-0 w-10 h-10 bg-orange-100 dark:bg-orange-900/30 rounded-lg flex items-center justify-center">
+            <HeartIcon class="h-5 w-5 text-orange-600 dark:text-orange-400" />
+          </div>
+          <div>
+            <h2 class="text-sm font-semibold text-gray-800 dark:text-gray-200 mb-1">Batteriezustand (SoH) verfolgen</h2>
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+              EV Monitor berechnet deinen State of Health aus deinen Ladetagebuch-Eintragem automatisch.
+              Fruhwarnung bei Degradation - relevant fur Garantie und Wiederverkauf.
+            </p>
+          </div>
+        </div>
+
+        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-5 flex gap-4">
+          <div class="shrink-0 w-10 h-10 bg-teal-100 dark:bg-teal-900/30 rounded-lg flex items-center justify-center">
+            <BuildingStorefrontIcon class="h-5 w-5 text-teal-600 dark:text-teal-400" />
+          </div>
+          <div>
+            <h2 class="text-sm font-semibold text-gray-800 dark:text-gray-200 mb-1">Ladeanbieter vergleichen</h2>
+            <p class="text-sm text-gray-500 dark:text-gray-400">
+              Welcher Anbieter ist fur dich am gunstigsten? EV Monitor wertet deine echten Ladevorgange aus
+              und zeigt Kosten pro kWh je Anbieter.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- Community Stats -->
+      <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-5 mb-8 text-center">
+        <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-4">
+          Echte Daten von echten EV-Fahrern
+        </h2>
+        <div class="grid grid-cols-3 gap-4">
+          <div>
+            <div class="text-xl font-bold text-green-600 dark:text-green-400">{{ stats?.userCount?.toLocaleString('de-DE') ?? '...' }}</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Fahrer</div>
+          </div>
+          <div>
+            <div class="text-xl font-bold text-green-600 dark:text-green-400">{{ stats?.validTripCount?.toLocaleString('de-DE') ?? '...' }}</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Ladevorgange</div>
+          </div>
+          <div>
+            <div class="text-xl font-bold text-green-600 dark:text-green-400">{{ stats?.modelCount ?? '...' }}</div>
+            <div class="text-xs text-gray-500 dark:text-gray-400 mt-0.5">Modelle</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Wer sollte ein Ladetagebuch fuhren? -->
+      <div class="mb-8">
+        <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-4">
+          Wer sollte ein Ladetagebuch fuhren?
+        </h2>
+        <ul class="space-y-2 text-sm text-gray-600 dark:text-gray-400">
+          <li class="flex items-start gap-2">
+            <CheckIcon class="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
+            <span><strong class="text-gray-800 dark:text-gray-200">Alle E-Auto-Besitzer</strong> - wer wissen will was sein Auto wirklich kostet</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <CheckIcon class="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
+            <span><strong class="text-gray-800 dark:text-gray-200">Dienstwagenfahrer</strong> - fur die korrekte Abrechnung von privaten Ladungen</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <CheckIcon class="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
+            <span><strong class="text-gray-800 dark:text-gray-200">Wiederverkaufer</strong> - SoH-Nachweis erhoht den Wiederverkaufswert</span>
+          </li>
+          <li class="flex items-start gap-2">
+            <CheckIcon class="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
+            <span><strong class="text-gray-800 dark:text-gray-200">Neugierige</strong> - wer den WLTP-Mythos mit eigenen Daten widerlegen will</span>
+          </li>
+        </ul>
+      </div>
+
+      <!-- FAQ -->
+      <div class="space-y-5 mb-10 text-sm text-gray-600 dark:text-gray-400">
+        <div>
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">
+            Was ist ein Ladetagebuch fur Elektroautos?
+          </h2>
+          <p>
+            Ein Ladetagebuch dokumentiert jeden Ladevorgang deines E-Autos: wann, wo, wie viel kWh,
+            zu welchem Preis und mit welchem Ergebnis (SoC). Ahnlich wie ein Fahrtenbuch - aber fur
+            das Laden statt fur das Tanken. EV Monitor digitalisiert diesen Prozess und macht ihn
+            weitgehend automatisch.
+          </p>
+        </div>
+        <div>
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">
+            Muss ich jeden Ladevorgang manuell eintragen?
+          </h2>
+          <p>
+            Nein - mit EV Monitor AutoSync (Premium-Feature fur €3,90/Monat) werden Ladevorgange
+            automatisch erfasst, wenn dein Fahrzeug verbunden ist. Fur Tesla, VW, Skoda, SEAT und CUPRA
+            wird automatisch synchronisiert. Manuelles Eintragen bleibt naturlich moglich und ist kostenlos.
+          </p>
+        </div>
+        <div>
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">
+            Ist EV Monitor kostenlos?
+          </h2>
+          <p>
+            Das Ladetagebuch mit manuellen Eintramen, Dashboard, Verbrauchsstatistiken und Community-Vergleich
+            ist komplett kostenlos. AutoSync (automatische Fahrzeuganbindung) ist ein optionales Premium-Feature.
+          </p>
+        </div>
+      </div>
+
+      <!-- Final CTA -->
+      <div class="bg-gradient-to-br from-gray-900 to-green-900 rounded-xl p-6 text-center">
+        <h2 class="text-lg font-bold text-white mb-2">Dein erstes Ladetagebuch - heute</h2>
+        <p class="text-gray-300 text-sm mb-4">
+          In 2 Minuten angemeldet. Direkt loslegen. Keine versteckten Kosten.
+        </p>
+        <a
+          href="/register"
+          class="inline-flex items-center gap-2 bg-green-500 hover:bg-green-400 text-white font-semibold px-6 py-3 rounded-lg transition-colors text-sm"
+        >
+          Kostenlos starten
+          <ArrowRightIcon class="h-4 w-4" />
+        </a>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useHead } from '@unhead/vue';
+import {
+  ArrowRightIcon,
+  BoltIcon,
+  ChartBarIcon,
+  ArrowTrendingUpIcon,
+  HeartIcon,
+  BuildingStorefrontIcon,
+  CheckIcon
+} from '@heroicons/vue/24/outline';
+import PublicNav from '../components/shared/PublicNav.vue';
+import { getPlatformStats, type PlatformStats } from '../api/publicModelService';
+
+useHead({
+  title: 'Digitales Ladetagebuch fur Elektroauto - Kosten und Verbrauch tracken | EV Monitor',
+  meta: [
+    {
+      name: 'description',
+      content: 'Kostenloses digitales Ladetagebuch fur Elektroautos. Ladekosten, Verbrauch, echte Reichweite und SoH automatisch tracken. Tesla, VW, Skoda, SEAT und mehr.'
+    },
+    { property: 'og:title', content: 'Digitales Ladetagebuch Elektroauto | EV Monitor' },
+    { property: 'og:description', content: 'Alle Ladevorgange erfassen, Kosten im Blick behalten, echte Reichweite sehen. Kostenlos starten.' }
+  ],
+  link: [{ rel: 'canonical', href: 'https://ev-monitor.net/ladetagebuch' }],
+  script: [
+    {
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'SoftwareApplication',
+        name: 'EV Monitor - Ladetagebuch fur Elektroautos',
+        description: 'Digitales Ladetagebuch: Ladekosten, Verbrauch, echte Reichweite und SoH tracken',
+        url: 'https://ev-monitor.net/ladetagebuch',
+        applicationCategory: 'UtilityApplication',
+        operatingSystem: 'Web',
+        offers: { '@type': 'Offer', price: '0', priceCurrency: 'EUR' },
+        breadcrumb: {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'EV Monitor', item: 'https://ev-monitor.net' },
+            { '@type': 'ListItem', position: 2, name: 'Ladetagebuch', item: 'https://ev-monitor.net/ladetagebuch' }
+          ]
+        }
+      })
+    }
+  ]
+});
+
+const stats = ref<PlatformStats | null>(null);
+
+onMounted(async () => {
+  try {
+    stats.value = await getPlatformStats();
+  } catch {
+    // stats bleiben null, Fallback-Text wird angezeigt
+  }
+});
+</script>

--- a/frontend/src/views/LandingPageV2View.vue
+++ b/frontend/src/views/LandingPageV2View.vue
@@ -369,6 +369,9 @@ onMounted(async () => {
         <span>{{ t('landing.footer.made_with') }}</span>
         <nav class="flex flex-wrap gap-4 justify-center">
           <a :href="modelsUrl" class="hover:text-gray-600 dark:hover:text-gray-300 transition">{{ t('landing.footer.models') }}</a>
+          <a href="/ladekosten-rechner" class="hover:text-gray-600 dark:hover:text-gray-300 transition">Ladekosten-Rechner</a>
+          <a href="/ladetagebuch" class="hover:text-gray-600 dark:hover:text-gray-300 transition">Ladetagebuch</a>
+          <a href="/echte-reichweite" class="hover:text-gray-600 dark:hover:text-gray-300 transition">Echte Reichweite</a>
           <router-link to="/datenschutz" class="hover:text-gray-600 dark:hover:text-gray-300 transition">{{ t('landing.footer.privacy') }}</router-link>
           <router-link to="/impressum" class="hover:text-gray-600 dark:hover:text-gray-300 transition">{{ t('landing.footer.imprint') }}</router-link>
           <a href="https://github.com/sebastianwien/ev-monitor" target="_blank" rel="noopener noreferrer" class="hover:text-gray-600 dark:hover:text-gray-300 transition">{{ t('landing.footer.github') }}</a>

--- a/frontend/src/views/VerbrauchVerstehenView.vue
+++ b/frontend/src/views/VerbrauchVerstehenView.vue
@@ -1,0 +1,309 @@
+<template>
+  <div class="min-h-screen bg-gray-50 dark:bg-gray-950">
+    <PublicNav />
+
+    <main class="max-w-2xl mx-auto px-4 py-8">
+      <!-- Hero -->
+      <div class="text-center mb-8">
+        <h1 class="text-2xl sm:text-3xl font-bold text-gray-900 dark:text-gray-100 mb-2 leading-tight">
+          E-Auto Verbrauch verstehen und tracken
+        </h1>
+        <p class="text-gray-500 dark:text-gray-400 text-sm sm:text-base max-w-xl mx-auto">
+          Warum verbraucht dein Elektroauto mehr als angegeben?
+          Was beeinflusst den Verbrauch? Wie trackst du ihn sinnvoll?
+        </p>
+      </div>
+
+      <!-- Inhalt: WLTP vs Real -->
+      <div class="space-y-6">
+
+        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-5">
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-3">
+            WLTP-Verbrauch vs. realer Verbrauch
+          </h2>
+          <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">
+            Der WLTP-Wert wird im Labor bei konstanten 23 Grad, ohne Heizung, ohne Klimaanlage
+            und auf einem definierten Geschwindigkeitsprofil gemessen. Die Realität sieht anders aus:
+          </p>
+          <!-- Visualisierung -->
+          <div class="space-y-3">
+            <div
+              v-for="factor in factors"
+              :key="factor.label"
+              class="flex items-center gap-3 text-sm"
+            >
+              <div class="w-32 shrink-0 text-gray-600 dark:text-gray-400">{{ factor.label }}</div>
+              <div class="flex-1 h-3 bg-gray-100 dark:bg-gray-700 rounded-full overflow-hidden">
+                <div
+                  class="h-full rounded-full transition-all"
+                  :style="{ backgroundColor: factor.bgHex, width: factor.impact + '%' }"
+                ></div>
+              </div>
+              <div class="w-24 text-right text-xs font-medium" :class="factor.textColor">
+                {{ factor.label2 }}
+              </div>
+            </div>
+          </div>
+          <p class="text-xs text-gray-400 mt-3">
+            Prozentuale Abweichung vom WLTP-Basisverbrauch (Quelle: Community-Daten + ADAC-Messungen)
+          </p>
+        </div>
+
+        <!-- Einflussfaktoren -->
+        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-5">
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-3">
+            Die 4 größten Einflussfaktoren
+          </h2>
+          <div class="space-y-4 text-sm text-gray-600 dark:text-gray-400">
+            <div class="flex gap-3">
+              <div class="shrink-0 w-8 h-8 bg-blue-100 dark:bg-blue-900/30 rounded-lg flex items-center justify-center">
+                <span class="text-blue-600 dark:text-blue-400 font-bold text-xs">1</span>
+              </div>
+              <div>
+                <div class="font-medium text-gray-800 dark:text-gray-200 mb-0.5">Temperatur</div>
+                <p>
+                  Kalte Akkus haben weniger nutzbare Kapazität - und die Heizung verbraucht bis zu 4 kW zusätzlich.
+                  Im Winter sind Mehrverbräuche von 30-50% gegenüber Sommer normal. Vorkonditionierung
+                  (Aufwärmen während dem Laden) reduziert den Effekt deutlich.
+                </p>
+              </div>
+            </div>
+            <div class="flex gap-3">
+              <div class="shrink-0 w-8 h-8 bg-orange-100 dark:bg-orange-900/30 rounded-lg flex items-center justify-center">
+                <span class="text-orange-600 dark:text-orange-400 font-bold text-xs">2</span>
+              </div>
+              <div>
+                <div class="font-medium text-gray-800 dark:text-gray-200 mb-0.5">Geschwindigkeit</div>
+                <p>
+                  Luftwiderstand steigt mit dem Quadrat der Geschwindigkeit. Bei 130 km/h
+                  verbraucht dasselbe Auto oft doppelt so viel wie bei 80 km/h.
+                  Wer viel Autobahn fährt, rechnet mit 25-50% Mehrverbrauch gegenüber Stadtverkehr.
+                </p>
+              </div>
+            </div>
+            <div class="flex gap-3">
+              <div class="shrink-0 w-8 h-8 bg-purple-100 dark:bg-purple-900/30 rounded-lg flex items-center justify-center">
+                <span class="text-purple-600 dark:text-purple-400 font-bold text-xs">3</span>
+              </div>
+              <div>
+                <div class="font-medium text-gray-800 dark:text-gray-200 mb-0.5">Batterie-Alterung (SoH)</div>
+                <p>
+                  Mit jedem Jahr sinkt die nutzbare Kapazität leicht. Ein Auto mit 90% SoH hat
+                  effektiv 10% weniger Reichweite als neu. Wer seinen SoH kennt, kann realistischer planen.
+                </p>
+              </div>
+            </div>
+            <div class="flex gap-3">
+              <div class="shrink-0 w-8 h-8 bg-teal-100 dark:bg-teal-900/30 rounded-lg flex items-center justify-center">
+                <span class="text-teal-600 dark:text-teal-400 font-bold text-xs">4</span>
+              </div>
+              <div>
+                <div class="font-medium text-gray-800 dark:text-gray-200 mb-0.5">Standby-Verbrauch</div>
+                <p>
+                  Fahrzeug-Software, Klimatisierung im Stand und Over-the-Air-Updates ziehen Strom
+                  auch ohne Fahrt. 1-3 kWh pro Tag sind normal - das beeinflusst den messbaren
+                  Verbrauch pro 100 km, wenn man die Energie einrechnet.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Wie sinnvoll tracken -->
+        <div class="bg-white dark:bg-gray-800 rounded-xl border border-gray-100 dark:border-gray-700 p-5">
+          <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-3">
+            Verbrauch richtig tracken
+          </h2>
+          <p class="text-sm text-gray-600 dark:text-gray-400 mb-3">
+            Der Bordcomputer zeigt nur den Motorzug während der Fahrt - nicht Standby, nicht Ladeverluste.
+            Wer seinen echten Verbrauch wissen will, braucht einen anderen Ansatz:
+          </p>
+          <ul class="space-y-2 text-sm text-gray-600 dark:text-gray-400">
+            <li class="flex items-start gap-2">
+              <CheckIcon class="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
+              <span>
+                <strong class="text-gray-800 dark:text-gray-200">Geladene kWh messen</strong> - an der Wallbox oder
+                Ladestation, nicht was der Bordcomputer sagt
+              </span>
+            </li>
+            <li class="flex items-start gap-2">
+              <CheckIcon class="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
+              <span>
+                <strong class="text-gray-800 dark:text-gray-200">km zwischen zwei Ladevorgangen</strong> notieren -
+                das ergibt den Verbrauch für genau diese Strecke inklusive aller Verluste
+              </span>
+            </li>
+            <li class="flex items-start gap-2">
+              <CheckIcon class="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
+              <span>
+                <strong class="text-gray-800 dark:text-gray-200">SoC-Korrekturfaktor</strong> mitrechnen -
+                wenn du nicht immer auf denselben SoC ladst, muss die Differenz einberechnet werden
+              </span>
+            </li>
+            <li class="flex items-start gap-2">
+              <CheckIcon class="h-4 w-4 text-green-500 shrink-0 mt-0.5" />
+                <span>
+                <strong class="text-gray-800 dark:text-gray-200">Median statt Mittelwert</strong> für den Jahresdurchschnitt -
+                einzelne Langstrecken oder extreme Wintertage verzerren den Mittelwert stark
+              </span>
+            </li>
+          </ul>
+        </div>
+
+        <!-- Community Stats -->
+        <div v-if="stats" class="bg-green-50 dark:bg-green-950/30 border border-green-100 dark:border-green-900 rounded-xl p-4 text-center">
+          <p class="text-sm text-green-700 dark:text-green-400">
+            EV Monitor berechnet den Verbrauch so für
+            <strong>{{ stats.validTripCount.toLocaleString('de-DE') }} Ladevorgänge</strong>
+            von <strong>{{ stats.userCount.toLocaleString('de-DE') }} Fahrern</strong>.
+            Die Methodik ist <a href="/consumption-methodology" class="underline">hier erklart</a>.
+          </p>
+        </div>
+
+        <!-- FAQ -->
+        <div class="space-y-4 text-sm text-gray-600 dark:text-gray-400">
+          <div>
+            <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">
+              Warum zeigt mein E-Auto mehr Verbrauch als der WLTP-Wert?
+            </h2>
+            <p>
+              Weil WLTP unter Idealbedingungen gemessen wird. Temperatur, Geschwindigkeit, Heizung
+              und Klimaanlage sind die Haupttreiber. Ein Verbrauch von 10-30% über WLTP ist völlig
+              normal und kein Zeichen für einen Defekt.
+            </p>
+          </div>
+          <div>
+            <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">
+              Stimmt der Verbrauch im Bordcomputer?
+            </h2>
+            <p>
+              Der Bordcomputer ist ein nützlicher Richtwert, misst aber nur den Antriebsstrom
+              während der Fahrt. Standby-Verluste, Ladeverluste und die Klimatisierung im Stand
+              tauchen dort nicht auf. Der echte Verbrauch aus der Steckdose ist höher.
+            </p>
+          </div>
+          <div>
+            <h2 class="text-base font-semibold text-gray-800 dark:text-gray-200 mb-1">
+              Wie verringere ich den Verbrauch im Winter?
+            </h2>
+            <p>
+              Vorkonditionieren während dem Laden ist der effektivste Hebel - der Akku wird auf
+              Betriebstemperatur gebracht ohne Akkustrom zu nutzen. Sitzheizung statt Geblase spart
+              2-3 kW. Eco-Modus und Tempolimit auf der Autobahn helfen ebenfalls.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <!-- CTA -->
+      <div class="mt-8 bg-gradient-to-br from-gray-900 to-green-900 rounded-xl p-6 text-center">
+        <h2 class="text-lg font-bold text-white mb-2">Deinen echten Verbrauch kennen</h2>
+        <p class="text-gray-300 text-sm mb-4">
+          EV Monitor berechnet deinen Verbrauch korrekt - aus geladenen kWh und gefahrenen km.
+          Nicht aus dem Bordcomputer.
+        </p>
+        <a
+          href="/register"
+          class="inline-flex items-center gap-2 bg-green-500 hover:bg-green-400 text-white font-semibold px-6 py-3 rounded-lg transition-colors text-sm"
+        >
+          Kostenlos starten
+          <ArrowRightIcon class="h-4 w-4" />
+        </a>
+      </div>
+    </main>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, onMounted } from 'vue';
+import { useHead } from '@unhead/vue';
+import { ArrowRightIcon, CheckIcon } from '@heroicons/vue/24/outline';
+import PublicNav from '../components/shared/PublicNav.vue';
+import { getPlatformStats, type PlatformStats } from '../api/publicModelService';
+
+useHead({
+  title: 'E-Auto Verbrauch verstehen - WLTP vs. real, Einflussfaktoren | EV Monitor',
+  meta: [
+    {
+      name: 'description',
+      content: 'Warum verbraucht dein E-Auto mehr als angegeben? WLTP vs. realer Verbrauch erklart: Temperatur, Autobahn, SoH - und wie du deinen Verbrauch richtig trackst.'
+    },
+    { property: 'og:title', content: 'E-Auto Verbrauch verstehen | EV Monitor' },
+    { property: 'og:description', content: 'WLTP vs. real: Einflussfaktoren auf den E-Auto Verbrauch und wie du ihn sinnvoll trackst.' }
+  ],
+  link: [{ rel: 'canonical', href: 'https://ev-monitor.net/verbrauch-verstehen' }],
+  script: [
+    {
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'Article',
+        headline: 'E-Auto Verbrauch verstehen - WLTP vs. real, Einflussfaktoren',
+        description: 'Warum verbraucht dein E-Auto mehr als angegeben? WLTP vs. realer Verbrauch erklärt.',
+        url: 'https://ev-monitor.net/verbrauch-verstehen',
+        author: { '@type': 'Person', name: 'Sebastian Ihle' },
+        publisher: { '@type': 'Organization', name: 'EV Monitor', url: 'https://ev-monitor.net' },
+        datePublished: '2026-04-30',
+        breadcrumb: {
+          '@type': 'BreadcrumbList',
+          itemListElement: [
+            { '@type': 'ListItem', position: 1, name: 'EV Monitor', item: 'https://ev-monitor.net' },
+            { '@type': 'ListItem', position: 2, name: 'Verbrauch verstehen', item: 'https://ev-monitor.net/verbrauch-verstehen' }
+          ]
+        }
+      })
+    },
+    {
+      type: 'application/ld+json',
+      innerHTML: JSON.stringify({
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        mainEntity: [
+          {
+            '@type': 'Question',
+            name: 'Warum zeigt mein E-Auto mehr Verbrauch als der WLTP-Wert?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'Weil WLTP unter Idealbedingungen gemessen wird. Temperatur, Geschwindigkeit, Heizung und Klimaanlage sind die Haupttreiber. Ein Verbrauch von 10-30% über WLTP ist völlig normal und kein Zeichen für einen Defekt.'
+            }
+          },
+          {
+            '@type': 'Question',
+            name: 'Stimmt der Verbrauch im Bordcomputer?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'Der Bordcomputer ist ein nützlicher Richtwert, misst aber nur den Antriebsstrom während der Fahrt. Standby-Verluste, Ladeverluste und die Klimatisierung im Stand tauchen dort nicht auf. Der echte Verbrauch aus der Steckdose ist höher.'
+            }
+          },
+          {
+            '@type': 'Question',
+            name: 'Wie verringere ich den Verbrauch im Winter?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'Vorkonditionieren während dem Laden ist der effektivste Hebel - der Akku wird auf Betriebstemperatur gebracht ohne Akkustrom zu nutzen. Sitzheizung statt Gebläse spart 2-3 kW. Eco-Modus und Tempolimit auf der Autobahn helfen ebenfalls.'
+            }
+          }
+        ]
+      })
+    }
+  ]
+});
+
+const stats = ref<PlatformStats | null>(null);
+
+const factors = [
+  { label: 'Winter (-15°C)', label2: '+40% Verbrauch', impact: 90, bgHex: '#3b82f6', textColor: 'text-blue-600 dark:text-blue-400' },
+  { label: 'Autobahn 130', label2: '+35% Verbrauch', impact: 75, bgHex: '#f97316', textColor: 'text-orange-600 dark:text-orange-400' },
+  { label: 'Herbst (10°C)', label2: '+20% Verbrauch', impact: 50, bgHex: '#facc15', textColor: 'text-yellow-600 dark:text-yellow-400' },
+  { label: 'Stadtverkehr', label2: '+10% Verbrauch', impact: 30, bgHex: '#4ade80', textColor: 'text-green-600 dark:text-green-400' },
+  { label: 'WLTP-Basis', label2: '0% Abweichung', impact: 15, bgHex: '#9ca3af', textColor: 'text-gray-500 dark:text-gray-400' },
+];
+
+onMounted(async () => {
+  try {
+    stats.value = await getPlatformStats();
+  } catch {
+    // bleibt null
+  }
+});
+</script>


### PR DESCRIPTION
## Summary

- 5 neue öffentliche SEO-Seiten ohne Auth-Guard, lazy-loaded im Router
- `/ladekosten-rechner` - interaktiver Strom-vs-Benzin-Kostenrechner mit Schiebereglern
- `/ladetagebuch` - Landing Page mit Live-Community-Stats aus der API
- `/echte-reichweite` - Real-Verbrauch vs. WLTP für Top-50-Modelle (Live-Daten)
- `/verbrauch-verstehen` - Erklärseite zu WLTP, Autobahn, Winter-Einflüssen
- `/elektroauto-kosten-pro-km` - Ranking der günstigsten E-Modelle (Live-Daten)

Alle Seiten: `useHead` + Canonical URL + JSON-LD (Article + FAQPage Schema). Footer in LandingPageV2 verlinkt 3 der Seiten.

`ladekostenCalc.ts` als eigenes Utility extrahiert (TDD: 6 Vitest-Tests).

## Test plan

- [ ] `/ladekosten-rechner` - Rechner live testen, Benzinvergleich-Toggle aus-/einblenden
- [ ] `/ladetagebuch` - Community-Stats laden korrekt
- [ ] `/echte-reichweite` - Modelltabelle + Abweichungs-Badges korrekt
- [ ] `/verbrauch-verstehen` - Seite rendert, Balken sichtbar
- [ ] `/elektroauto-kosten-pro-km` - Ranking lädt + Strompreis-Slider reaktiv
- [ ] `npm test` - alle 6 ladekostenCalc-Tests grün
- [ ] Mobile-Ansicht auf allen 5 Seiten checken