### PR TITLE
fix(logs): Zeitraum-Feed zeigt gefahrene km auch fuer reine Lade-User

### DIFF
--- a/frontend/src/utils/__tests__/tripPeriods.test.ts
+++ b/frontend/src/utils/__tests__/tripPeriods.test.ts
@@ -161,6 +161,38 @@ describe('buildPeriodGroups', () => {
     expect(groups[0].days[0].charges.map((c: any) => c.id)).toEqual(['c1'])
   })
 
+  it('zaehlt bei reinen Ladetagen die gefahrenen km aus dem Odometer-Delta der Ladungen', () => {
+    // Import-User (XPeng, Spritmonitor) zeichnen keine Fahrten auf - ihre Strecke steckt
+    // im Odometer-Sprung zwischen den Ladungen, nicht in einer Trip-Liste.
+    const chargeOnly = [
+      { id: 'a', loggedAt: '2026-08-27T18:00:00', kwh: 20, distanceSinceLastChargeKm: 137 },
+      { id: 'b', loggedAt: '2026-08-27T12:00:00', kwh: 20, distanceSinceLastChargeKm: 123 },
+      { id: 'c', loggedAt: '2026-08-26T11:00:00', kwh: 20, distanceSinceLastChargeKm: null },
+    ]
+    const [august] = buildPeriodGroups([], chargeOnly, 'month', measure)
+
+    expect(august.totals.km).toBe(260)
+    expect(august.totals.tripCount).toBe(0)
+  })
+
+  it('faellt fuer die Strecke nur auf Ladungen zurueck, wenn es keine Fahrten gibt', () => {
+    // Fahrten sind die genauere Quelle - ihr Odometer-Delta darf nicht zusaetzlich zaehlen.
+    const withOdo = charges.map((c) => ({ ...c, distanceSinceLastChargeKm: 500 }))
+    const [august] = buildPeriodGroups(trips, withOdo, 'month', measure)
+
+    expect(august.totals.km).toBe(100)
+  })
+
+  it('faerbt Tagesbalken und Tag einer reinen Ladewoche aus dem Ladungs-Odometer', () => {
+    const chargeOnly = [
+      { id: 'a', loggedAt: '2026-08-25T18:00:00', kwh: 20, distanceSinceLastChargeKm: 42 },
+    ]
+    const [woche] = buildPeriodGroups([], chargeOnly, 'week', measure)
+
+    expect(woche.bars!.find((b) => b.dateKey === '2026-08-25')!.km).toBe(42)
+    expect(woche.days.find((d: any) => d.dateKey === '2026-08-25')!.km).toBe(42)
+  })
+
   it('ordnet Zeitraeume nach Datum, egal woher sie kamen', () => {
     // Eine Ladung eroeffnet einen Monat, der zwischen zwei Fahrtmonaten liegt.
     const groups = buildPeriodGroups(

--- a/frontend/src/utils/tripPeriods.ts
+++ b/frontend/src/utils/tripPeriods.ts
@@ -83,6 +83,8 @@ export interface PeriodTripInput {
 
 export interface PeriodChargeInput {
   loggedAt?: string | null
+  /** Odometer-Delta zur vorigen Ladung - die einzige Streckenquelle fuer reine Lade-User. */
+  distanceSinceLastChargeKm?: number | null
 }
 
 /** Woher die Werte kommen, die diese Datei nur noch addiert. */
@@ -150,12 +152,18 @@ function barsFor<T extends PeriodTripInput, C extends PeriodChargeInput>(
     const day = trip.tripStartedAt?.slice(0, 10)
     if (day) kmByDay.set(day, (kmByDay.get(day) ?? 0) + (trip.distanceKm ?? 0))
   }
-  const chargedDays = new Set(
-    charges.map((charge) => charge.loggedAt?.slice(0, 10)).filter(Boolean) as string[],
-  )
+  // Ohne Fahrt am Tag zaehlt der Odometer-Sprung der Ladungen als gefahrene Strecke.
+  const chargeKmByDay = new Map<string, number>()
+  const chargedDays = new Set<string>()
+  for (const charge of charges) {
+    const day = charge.loggedAt?.slice(0, 10)
+    if (!day) continue
+    chargedDays.add(day)
+    chargeKmByDay.set(day, (chargeKmByDay.get(day) ?? 0) + (charge.distanceSinceLastChargeKm ?? 0))
+  }
   return axis.map((dateKey) => ({
     dateKey,
-    km: kmByDay.get(dateKey) ?? 0,
+    km: kmByDay.get(dateKey) ?? chargeKmByDay.get(dateKey) ?? 0,
     charged: chargedDays.has(dateKey),
   }))
 }
@@ -199,9 +207,12 @@ function totalsOf<T extends PeriodTripInput, C extends PeriodChargeInput>(
   }
 
   const chargedKwh = charges.reduce((sum, charge) => sum + (measure.chargeKwhOf(charge) ?? 0), 0)
+  // Reine Lade-User (Import ohne Fahrten) haben ihre Strecke nur im Odometer-Delta der
+  // Ladungen. Fahrten sind die genauere Quelle - ihr Delta darf nicht zusaetzlich zaehlen.
+  const chargeKm = charges.reduce((sum, charge) => sum + (charge.distanceSinceLastChargeKm ?? 0), 0)
 
   return {
-    km,
+    km: trips.length > 0 ? km : chargeKm,
     tripCount: trips.length,
     chargeCount: charges.length,
     chargedKwh,
@@ -297,7 +308,13 @@ function daysOf<T extends PeriodTripInput, C extends PeriodChargeInput>(
     }
     day.charges.push(charge)
   }
-  for (const day of days) day.events = mergeDayEvents(day.trips, day.charges)
+  for (const day of days) {
+    day.events = mergeDayEvents(day.trips, day.charges)
+    // Ladetag ohne Fahrt: gefahrene Strecke steckt im Odometer-Delta der Ladungen.
+    if (day.tripCount === 0) {
+      day.km = day.charges.reduce((sum, charge) => sum + (charge.distanceSinceLastChargeKm ?? 0), 0)
+    }
+  }
   return days.sort((a, b) => b.dateKey.localeCompare(a.dateKey))
 }
 


### PR DESCRIPTION
## Problem
Im Zeitraum-Feed (Tag/Woche/Monat - Default-Ansicht) wurde die gefahrene Strecke ("+X km") **nur aus Fahrten** (`trip.distanceKm`) berechnet. User ohne Trip-Erfassung - XPeng-/Spritmonitor-Import, manuelle Logs - haben keine Trips und sahen deshalb durchgaengig **"+0 km"**, obwohl der Odometer ihrer Ladungen echte Strecke ausweist.

Gemeldet von zwei Usern (ID.3 und XPeng G6) - connector-unabhaengig, weil rein im Frontend-Rendering. Die Daten selbst sind vollstaendig (alle Logs haben `odometer_km`).

## Fix
Fehlen Fahrten, faellt die km-Berechnung auf das Odometer-Delta der Ladungen (`distanceSinceLastChargeKm`, vom Backend geliefert) zurueck - in `totalsOf` (Gruppen-Header), `barsFor` (Tagesbalken) und `daysOf` (Tag). Sind Fahrten vorhanden, bleiben diese die alleinige Quelle, damit das Ladungs-Delta nicht doppelt zaehlt.

## Tests
TDD: 3 neue Faelle in `tripPeriods.test.ts` (reine Ladeperiode summiert Odometer-Delta; kein Doppelzaehlen bei vorhandenen Fahrten; Tagesbalken/Tag einer reinen Ladewoche). Alle 972 Frontend-Unit-Tests gruen, Typecheck ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)